### PR TITLE
Feature/timing-monitor: 주기 모니터링 모듈 (Cyclic Transmission)

### DIFF
--- a/src/monitor/timing_monitor.py
+++ b/src/monitor/timing_monitor.py
@@ -1,1 +1,98 @@
 # src/monitor/timing_monitor.py
+
+import can
+import time
+from logger.base_logger import log_event
+
+
+# 모니터링 설정값 
+CAN_CHANNEL = "can0"           # 사용할 CAN 인터페이스 
+TARGET_ID = 0x366              # Blinkmodi_02
+EXPECTED_CYCLE_MS = 1000       # 기대 주기 
+TOLERANCE_MS = 50              # 허용 오차
+LOG_INTERVAL = 10              # 평균 주기 출력 주기 (10프레임마다 평균 계산)
+
+
+class TimingMonitor:
+    def __init__(self,
+                 channel: str = CAN_CHANNEL,
+                 target_id: int = TARGET_ID,
+                 expected_cycle: int = EXPECTED_CYCLE_MS,
+                 tolerance: int = TOLERANCE_MS):
+        """
+        :param channel: CAN 인터페이스 이름
+        :param target_id: 모니터링 대상 CAN ID
+        :param expected_cycle: 기대 주기(ms)
+        :param tolerance: 허용 오차(ms)
+        """
+        self.channel = channel
+        self.target_id = target_id
+        self.expected = expected_cycle
+        self.tolerance = tolerance
+
+        # pycan 인터페이스 초기화
+        self.bus = can.interface.Bus(channel=self.channel, bustype="socketcan")
+
+        # 내부 상태 관리
+        self.prev_time = None     # 이전 메시지 수신 시각
+        self.events = []          # 발생한 이벤트 버퍼
+        self._frame_counter = 0   # 평균 주기 계산용 카운터
+        self._cycle_list = []     # 최근 N개의 주기 기록
+
+
+    def start(self):
+        """
+        모니터링 루프 시작.
+        지정된 CAN ID의 메시지를 수신하며, 주기 위배 여부를 검사한다.
+        """
+        print(f"[ INFO ] Monitoring 0x{self.target_id:X} "
+              f"(Cycle={self.expected}ms ±{self.tolerance}ms) on {self.channel}")
+
+        while True:
+            msg = self.bus.recv(timeout=1)
+            if not msg:
+                continue
+
+            # 지정한 CAN ID만 필터링
+            if msg.arbitration_id != self.target_id:
+                continue
+
+            now = time.time() * 1000  # 현재 시각(ms)
+            if self.prev_time:
+                cycle = now - self.prev_time
+                status = "OK" if (self.expected - self.tolerance <= cycle <= self.expected + self.tolerance) else "FAIL"
+
+                # 이벤트 생성 및 저장
+                event = {
+                    "type": "timing",
+                    "id": self.target_id,
+                    "metric": "cycle_time",
+                    "value": round(cycle, 2),
+                    "status": status
+                }
+                self.events.append(event)
+
+                # 공통 로거에 기록
+                log_event("timing", self.target_id, "cycle_time", cycle, status)
+
+                # CLI 출력
+                print(f"[{status}] Cycle: {cycle:.2f} ms")
+
+                # 평균 주기 계산 (optional)
+                self._frame_counter += 1
+                self._cycle_list.append(cycle)
+                if self._frame_counter % LOG_INTERVAL == 0:
+                    avg_cycle = sum(self._cycle_list[-LOG_INTERVAL:]) / LOG_INTERVAL
+                    print(f"    └ Average cycle (last {LOG_INTERVAL}): {avg_cycle:.2f} ms")
+
+            self.prev_time = now
+
+
+    def fetch_events(self):
+        """
+        Manager 또는 Pipeline에서 호출하여, 새로 수집된 이벤트를 반환한다.
+        반환 후 내부 버퍼(self.events)는 초기화된다.
+        """
+        events_copy = self.events[:]
+        self.events.clear()
+        return events_copy


### PR DESCRIPTION
## 📌 PR 개요
- Blinkmodi_02 (0x366) 전용 **주기(Cyclic Transmission) 모니터링 모듈**을 추가했습니다.
- CAN 메시지의 송신 주기를 실시간으로 측정하여 OK/FAIL을 판정하고, 평균 주기를 계산합니다.

## 🔍 주요 변경 사항
- `src/monitor/timing_monitor.py` 추가
  - `TimingMonitor` 클래스 구현
  - CAN 메시지 송신 간격(Δt)을 측정하고 기대 주기(±tolerance) 내 판정 수행
  - 결과는 `log_event()`를 통해 JSONL 포맷으로 로그 저장
- 설정 상단 분리
  - `CAN_CHANNEL`, `TARGET_ID`, `EXPECTED_CYCLE_MS`, `TOLERANCE_MS` 등 주요 파라미터 수정 가능

## ✅ 체크리스트
- [x] Blinkmodi_02 메시지 (0x366) 주기 모니터링 구현
- [ ] Signal Stability / Jitter Check 추가
- [ ] Timeout Detection 추가

## ⚠️ 기타 참고 사항
- 추후 `MonitorManager`에서 여러 ID를 병렬 모니터링할 예정입니다.
- `socketcan` 인터페이스 기반으로 구성되어 Raspberry Pi, PCAN 등 호환 가능합니다.
