### PR TITLE
Feature/dbc_monitor: DBC기반 fail 정의

### DIFF
--- a/src/monitor/dbc_monitor.py
+++ b/src/monitor/dbc_monitor.py
@@ -1,1 +1,119 @@
-# src/monitor/dbc_monitor.py
+# src/monitor/dbc_monitor_bool.py
+# DBC 기반 1-bit 신호 모니터
+
+import time
+import can
+import cantools
+from typing import Dict, Any, Optional, List
+from logger.base_logger import log_event
+
+
+CAN_CHANNEL = "can0"
+DBC_PATH    = "db/your.ecu.dbc"   # 실제 경로로 교체
+TARGET_ID   = 0x366               # Blinkmodi_02
+
+# ─────────────────────────────────────────────────────────────────────────────
+
+class DBCMonitor:
+    """
+    - decode/type check: 디코드 실패는 즉시 FAIL
+    - (선택) range check: min/max(보통 0/1) — enum과 동일 효과
+    - (선택) monotonic: "nondecreasing" 또는 "nonincreasing"
+      * nondecreasing: 1→0 금지 (0->1은 허용, '한 번 켜지면 유지')
+      * nonincreasing: 0→1 금지 (1->0은 허용, '한 번 꺼지면 유지')
+    """
+
+    def __init__(self,
+                 channel: str = CAN_CHANNEL,
+                 dbc_path: str = DBC_PATH,
+                 target_id: int = TARGET_ID,
+                 rules: Optional[Dict[str, Dict[str, Any]]] = None):
+        self.channel = channel
+        self.dbc_path = dbc_path
+        self.target_id = target_id
+        self.rules = rules or {}
+
+        # CAN / DBC 초기화
+        self.bus = can.interface.Bus(channel=self.channel, bustype="socketcan")
+        self.db  = cantools.database.load_file(self.dbc_path)
+        self.msg_def = self.db.get_message_by_frame_id(self.target_id)
+        if self.msg_def is None:
+            raise ValueError(f"DBC에 ID 0x{self.target_id:X} 메시지 정의가 없습니다.")
+
+        # 내부 상태
+        self._prev_values: Dict[str, int] = {}  # 각 신호의 직전 값(0/1)
+        self.events: List[Dict[str, Any]] = []
+
+    # ─────────────────────────────────────────────────────────────────────────
+    def start(self):
+        print(f"[ INFO ] DBCBoolMonitor: 0x{self.target_id:X} on {self.channel}")
+        print(f"         DBC={self.dbc_path}, signals={list(self.rules.keys()) or '—'}")
+
+        while True:
+            msg = self.bus.recv(timeout=1)
+            if not msg or msg.arbitration_id != self.target_id:
+                continue
+
+            try:
+                decoded = self.msg_def.decode(bytes(msg.data), decode_choices=True, scaling=True)
+            except Exception as e:
+                self._emit("decode_error", "_frame", str(e), "FAIL")
+                print(f"[FAIL] decode_error: {e}")
+                continue
+
+            # 신호별 검사
+            for sig, rule in self.rules.items():
+                if sig not in decoded:
+                    self._emit("missing_signal", sig, None, "FAIL")
+                    print(f"[FAIL] {sig}: missing in decoded")
+                    continue
+
+                # bool로 강제 캐스팅(0/1), float로 오더라도 정규화
+                val = int(float(decoded[sig]))
+                self._check_bool_rules(sig, val, rule)
+
+    # ─────────────────────────────────────────────────────────────────────────
+    def _check_bool_rules(self, sig: str, val: int, rule: Dict[str, Any]):
+        # 1) decode/type check는 상위에서 처리됨 (여기선 값 기준 검증)
+
+        # 2) enum
+        allowed = set(rule.get("enum", [0, 1]))  # 기본 0/1 허용
+        if val not in allowed:
+            self._emit("enum", sig, val, "FAIL")
+            print(f"[FAIL] {sig}: {val} not in {sorted(allowed)}")
+            # enum 위반 시 추가 검사 의미 없음
+            self._prev_values[sig] = val
+            return
+        else:
+            self._emit("enum", sig, val, "OK")
+
+        # 3) range 확인 — 보통 0~1로 enum과 동일 효과
+        if "min" in rule or "max" in rule:
+            mn = rule.get("min", 0)
+            mx = rule.get("max", 1)
+            status = "OK" if (mn <= val <= mx) else "FAIL"
+            self._emit("range", sig, val, status)
+            if status == "FAIL":
+                print(f"[FAIL] {sig}: {val} out of [{mn}, {mx}]")
+
+        # 상태 갱신
+        self._prev_values[sig] = val
+
+    # ─────────────────────────────────────────────────────────────────────────
+    def _emit(self, metric: str, sig: str, value: Any, status: str):
+        ev = {
+            "type": "dbc",
+            "id": self.target_id,
+            "metric": metric,   # enum | range | monotonic | decode_error | missing_signal
+            "signal": sig,
+            "value": value,
+            "status": status,
+            "ts_ms": int(time.time() * 1000),
+        }
+        self.events.append(ev)
+        log_event("dbc", self.target_id, f"{sig}:{metric}", value, status)
+
+    def fetch_events(self):
+        out = self.events[:]
+        self.events.clear()
+        return out

--- a/src/monitor/dbc_monitor.py
+++ b/src/monitor/dbc_monitor.py
@@ -1,47 +1,69 @@
 # src/monitor/dbc_monitor.py
-# DBC 기반 1-bit 신호 모니터
+# DBC 기반 신호 모니터 (1-bit + multi-bit, monotonic, raise on errors)
 
 import time
 import can
 import cantools
-from typing import Dict, Any, Optional, List
+from typing import Dict, Any, Optional, List, Union
 from logger.base_logger import log_event
 from seeds.seed_manager import SeedManager
 
 
 CAN_CHANNEL = "can0"
-DBC_PATH    = "db/your.ecu.dbc"   # 실제 경로로 교체
-TARGET_ID   = 0x366               # Blinkmodi_02
-
-# ─────────────────────────────────────────────────────────────────────────────
+DBC_PATH    = "db/your.ecu.dbc"   
+TARGET_ID   = 0x366               
+Number = Union[int, float]
 
 class DBCMonitor:
-    def _infer_rules_from_seeds(self, seeds, target_id):
-        rules = {}
+    # ─────────────────────────────────────────────────────────────────────
+    def _infer_rules_from_seeds(self, seeds, target_id): # Seed db에서 규칙 자동생성
+        rules: Dict[str, Dict[str, Any]] = {}
         for sd in seeds:
             if sd.message_id != target_id:
                 continue
-            meta = sd.metadata or {}
-            length = getattr(meta, "length", None) or (meta.get("length") if isinstance(meta, dict) else None)
-            if length != 1:
-                continue
 
-            mn = (meta.minimum if hasattr(meta, "minimum") else meta.get("minimum", 0))
-            mx = (meta.maximum if hasattr(meta, "maximum") else meta.get("maximum", 1))
-            enum_vals = meta.get("enum", [0, 1])  # 메타에 enum이 있으면 그대로 사용
+            meta = getattr(sd, "metadata", {}) or {}
+            def m(key, default=None): # 메타 접근 헬퍼 함수 : dict/객체 양쪽을 동일하게 다룸
+                if isinstance(meta, dict):
+                    return meta.get(key, default)
+                return getattr(meta, key, default)
 
-            rule = {"enum": enum_vals, "min": mn, "max": mx}
+            length  = m("length")
+            factor  = m("factor")
+            minimum = m("minimum")
+            maximum = m("maximum")
+            enum    = m("enum")
+            mono    = m("monotonic")
 
-            rules[sd.signal_name] = rule
-        return rules
-    
+            if length == 1: # 1-bit 신호 불린 판단
+                kind = "bool"; coerce_int = True # 오차 허용 불필요 항상 int 강제
+                default_enum = [0, 1]; default_min, default_max = 0, 1 # 기본 불린 규칙 설정
+            else:
+                if factor not in (None, 0, 1):
+                    kind = "float"; coerce_int = False
+                else:
+                    kind = "int"; coerce_int = True
+                default_enum = None
+                default_min, default_max = minimum, maximum
+
+            rule = { # 추론된 규칙 생성
+                "kind": kind,
+                "enum": enum if enum is not None else default_enum,
+                "min": default_min,
+                "max": default_max,
+                "monotonic": mono if mono in ("nondecreasing", "nonincreasing") else None,
+                "coerce_int": coerce_int,
+            }
+            rules[sd.signal_name] = rule # 신호명 규칙 매핑에 추가
+        return rules # 규칙 반환
+
+    # ─────────────────────────────────────────────────────────────────────
     def __init__(self,
                  channel: str = CAN_CHANNEL,
                  dbc_path: str = DBC_PATH,
                  target_id: int = TARGET_ID,
                  rules: Optional[Dict[str, Dict[str, Any]]] = None,
-                 seed_db_path: str = "db/seeds.sqlite" 
-                 ):
+                 seed_db_path: str = "db/seeds.sqlite"):
         self.channel = channel
         self.dbc_path = dbc_path
         self.target_id = target_id
@@ -52,8 +74,8 @@ class DBCMonitor:
         self.db  = cantools.database.load_file(self.dbc_path)
         self.msg_def = self.db.get_message_by_frame_id(self.target_id)
         if self.msg_def is None:
-            raise ValueError(f"DBC에 ID 0x{self.target_id:X} 메시지 정의가 없습니다.")
-        
+            raise ValueError(f"DBC에 ID 0x{self.target_id:X} 메시지 정의가 없습니다.") # 해당 메시지 없을 경우 예외 처리
+
         # Seed DB에서 규칙 자동 구성
         if not self.rules:
             manager = SeedManager(seed_db_path)
@@ -64,10 +86,10 @@ class DBCMonitor:
                 print("[WARN] Seed DB에서 규칙을 찾지 못했습니다. 검증 없이 모니터링을 진행합니다.")
 
         # 내부 상태
-        self._prev_values: Dict[str, int] = {}  # 각 신호의 직전 값(0/1)
+        self._prev_values: Dict[str, Number] = {}  # 직전값(단조성 검사용)
         self.events: List[Dict[str, Any]] = []
 
-    # ─────────────────────────────────────────────────────────────────────────
+    # ─────────────────────────────────────────────────────────────────────
     def start(self):
         print(f"[ INFO ] DBCMonitor: 0x{self.target_id:X} on {self.channel}")
         print(f"         DBC={self.dbc_path}, signals={list(self.rules.keys()) or '—'}")
@@ -77,66 +99,97 @@ class DBCMonitor:
             if not msg or msg.arbitration_id != self.target_id:
                 continue
 
+            # 디코드 실패는 즉시 예외로 올림
             try:
-                # choices를 숫자로 받기 위해 False 권장
                 decoded = self.msg_def.decode(bytes(msg.data), decode_choices=False, scaling=True)
             except Exception as e:
                 self._emit("decode_error", "_frame", str(e), "FAIL")
-                print(f"[FAIL] decode_error: {e}")
-                continue
+                raise RuntimeError(f"DBC decode 실패: {e}") from e
 
             # 신호별 검사
             for sig, rule in self.rules.items():
                 if sig not in decoded:
                     self._emit("missing_signal", sig, None, "FAIL")
-                    print(f"[FAIL] {sig}: missing in decoded")
-                    continue
+                    raise RuntimeError(f"신호 누락: {sig} - DBC에 정의된 신호가 디코딩 결과에 없습니다.")
 
-                # bool로 강제 캐스팅(0/1), float로 오더라도 정규화, 타입 일관성 보장
+                raw = decoded[sig]
+
+                # 타입 정규화 실패는 즉시 예외
                 try:
-                    val = int(float(decoded[sig]))
-                except Exception:
-                    # 혹시라도 문자열/예외가 들어오면 방어
-                    self._emit("type_cast", sig, decoded[sig], "FAIL")
-                    print(f"[FAIL] {sig}: cannot cast value={decoded[sig]!r} to int")
-                    continue
+                    val = self._normalize_value(raw, rule)
+                except Exception as e:
+                    self._emit("type_cast", sig, raw, "FAIL")
+                    raise ValueError(f"type cast 실패: signal={sig}, value={raw!r}") from e
 
-                self._check_bool_rules(sig, val, rule)
+                self._check_rules(sig, val, rule)
 
-    # ─────────────────────────────────────────────────────────────────────────
-    def _check_bool_rules(self, sig: str, val: int, rule: Dict[str, Any]):
-        # 1) decode/type check는 상위에서 처리됨 (여기선 값 기준 검증)
+    # ─────────────────────────────────────────────────────────────────────
+    def _normalize_value(self, raw: Any, rule: Dict[str, Any]) -> Number: # 규칙에 맞춰 값을 bool/int/float로 정규화
+        kind = rule.get("kind", "int")
+        if kind == "bool":
+            v = int(float(raw))
+            return 1 if v != 0 else 0  # 안전한 0/1화
+        if kind == "int":
+            if rule.get("coerce_int", True):
+                return int(float(raw))
+            if isinstance(raw, int):
+                return raw
+            return int(raw) if (isinstance(raw, float) and raw.is_integer()) else raw
+        # float
+        return float(raw)
 
-        # 2) enum
-        allowed = set(rule.get("enum", [0, 1]))  # 기본 0/1 허용
-        if val not in allowed:
-            self._emit("enum", sig, val, "FAIL")
-            print(f"[FAIL] {sig}: {val} not in {sorted(allowed)}")
-            # enum 위반 시 추가 검사 의미 없음
-            self._prev_values[sig] = val
-            return
-        else:
-            self._emit("enum", sig, val, "OK")
+    # ─────────────────────────────────────────────────────────────────────
+    def _check_rules(self, sig: str, val: Number, rule: Dict[str, Any]):
 
-        # 3) range 확인 — 보통 0~1로 enum과 동일 효과
-        if "min" in rule or "max" in rule:
-            mn = rule.get("min", 0)
-            mx = rule.get("max", 1)
-            status = "OK" if (mn <= val <= mx) else "FAIL"
-            self._emit("range", sig, val, status)
-            if status == "FAIL":
-                print(f"[FAIL] {sig}: {val} out of [{mn}, {mx}]")
+        #enum 검사
+        enum_vals = rule.get("enum")
+        if enum_vals is not None:
+            if rule.get("kind") == "float":
+                ok = any(float(val) == float(a) for a in enum_vals)
+            else:
+                ok = val in set(int(a) for a in enum_vals)
 
-        # 상태 갱신
-        self._prev_values[sig] = val
+            self._emit("enum", sig, val, "OK" if ok else "FAIL")
+            if not ok:
+                raise RuntimeError(f"enum 위반: {sig} value={val}, 허용={enum_vals}")
 
-    # ─────────────────────────────────────────────────────────────────────────
+        # range 검사
+        mn, mx = rule.get("min"), rule.get("max")
+
+        if mn is not None and float(val) < float(mn):
+            self._emit("range", sig, val, "FAIL")
+            raise RuntimeError(f"range 하한 위반: {sig} value={val}, min={mn}")
+
+        if mx is not None and float(val) > float(mx):
+            self._emit("range", sig, val, "FAIL")
+            raise RuntimeError(f"range 상한 위반: {sig} value={val}, max={mx}")
+
+        self._emit("range", sig, val, "OK")
+
+        # 단조성 검사
+        mode = rule.get("monotonic")
+        if mode:
+            prev = self._prev_values.get(sig)
+            if prev is not None:
+                pv = float(prev)
+                cv = float(val)
+                if mode == "nondecreasing" and cv < pv:
+                    self._emit("monotonic", sig, {"prev": prev, "cur": val, "mode": mode}, "FAIL")
+                    raise RuntimeError(f"단조성 위반: {sig} {prev} → {val} (nondecreasing)")
+                if mode == "nonincreasing" and cv > pv:
+                    self._emit("monotonic", sig, {"prev": prev, "cur": val, "mode": mode}, "FAIL")
+                    raise RuntimeError(f"단조성 위반: {sig} {prev} → {val} (nonincreasing)")
+            self._emit("monotonic", sig, {"prev": prev, "cur": val, "mode": mode}, "OK") # prev가 없거나 위반이 없으면 OK로 기록
+
+        self._prev_values[sig] = val # 정상 통과 시 이전값 갱신
+
+    # ─────────────────────────────────────────────────────────────────────
     def _emit(self, metric: str, sig: str, value: Any, status: str):
         ev = {
             "type": "dbc",
             "id": self.target_id,
-            "metric": metric,   # enum | range 
-            "signal": sig,
+            "metric": metric,
+            "signal": sig,   
             "value": value,
             "status": status,
             "ts_ms": int(time.time() * 1000),

--- a/src/monitor/dbc_monitor.py
+++ b/src/monitor/dbc_monitor.py
@@ -1,4 +1,4 @@
-# src/monitor/dbc_monitor_bool.py
+# src/monitor/dbc_monitor.py
 # DBC 기반 1-bit 신호 모니터
 
 import time
@@ -6,6 +6,7 @@ import can
 import cantools
 from typing import Dict, Any, Optional, List
 from logger.base_logger import log_event
+from seeds.seed_manager import SeedManager
 
 
 CAN_CHANNEL = "can0"
@@ -15,19 +16,32 @@ TARGET_ID   = 0x366               # Blinkmodi_02
 # ─────────────────────────────────────────────────────────────────────────────
 
 class DBCMonitor:
-    """
-    - decode/type check: 디코드 실패는 즉시 FAIL
-    - (선택) range check: min/max(보통 0/1) — enum과 동일 효과
-    - (선택) monotonic: "nondecreasing" 또는 "nonincreasing"
-      * nondecreasing: 1→0 금지 (0->1은 허용, '한 번 켜지면 유지')
-      * nonincreasing: 0→1 금지 (1->0은 허용, '한 번 꺼지면 유지')
-    """
+    def _infer_rules_from_seeds(self, seeds, target_id):
+        rules = {}
+        for sd in seeds:
+            if sd.message_id != target_id:
+                continue
+            meta = sd.metadata or {}
+            length = getattr(meta, "length", None) or (meta.get("length") if isinstance(meta, dict) else None)
+            if length != 1:
+                continue
 
+            mn = (meta.minimum if hasattr(meta, "minimum") else meta.get("minimum", 0))
+            mx = (meta.maximum if hasattr(meta, "maximum") else meta.get("maximum", 1))
+            enum_vals = meta.get("enum", [0, 1])  # 메타에 enum이 있으면 그대로 사용
+
+            rule = {"enum": enum_vals, "min": mn, "max": mx}
+
+            rules[sd.signal_name] = rule
+        return rules
+    
     def __init__(self,
                  channel: str = CAN_CHANNEL,
                  dbc_path: str = DBC_PATH,
                  target_id: int = TARGET_ID,
-                 rules: Optional[Dict[str, Dict[str, Any]]] = None):
+                 rules: Optional[Dict[str, Dict[str, Any]]] = None,
+                 seed_db_path: str = "db/seeds.sqlite" 
+                 ):
         self.channel = channel
         self.dbc_path = dbc_path
         self.target_id = target_id
@@ -39,6 +53,15 @@ class DBCMonitor:
         self.msg_def = self.db.get_message_by_frame_id(self.target_id)
         if self.msg_def is None:
             raise ValueError(f"DBC에 ID 0x{self.target_id:X} 메시지 정의가 없습니다.")
+        
+        # Seed DB에서 규칙 자동 구성
+        if not self.rules:
+            manager = SeedManager(seed_db_path)
+            seeds = manager.get_all()
+            self.rules = self._infer_rules_from_seeds(seeds, self.target_id)
+            print(f"[INFO] Seed DB로부터 {len(self.rules)}개의 신호 규칙을 불러왔습니다.")
+            if not self.rules:
+                print("[WARN] Seed DB에서 규칙을 찾지 못했습니다. 검증 없이 모니터링을 진행합니다.")
 
         # 내부 상태
         self._prev_values: Dict[str, int] = {}  # 각 신호의 직전 값(0/1)
@@ -46,7 +69,7 @@ class DBCMonitor:
 
     # ─────────────────────────────────────────────────────────────────────────
     def start(self):
-        print(f"[ INFO ] DBCBoolMonitor: 0x{self.target_id:X} on {self.channel}")
+        print(f"[ INFO ] DBCMonitor: 0x{self.target_id:X} on {self.channel}")
         print(f"         DBC={self.dbc_path}, signals={list(self.rules.keys()) or '—'}")
 
         while True:
@@ -55,7 +78,8 @@ class DBCMonitor:
                 continue
 
             try:
-                decoded = self.msg_def.decode(bytes(msg.data), decode_choices=True, scaling=True)
+                # choices를 숫자로 받기 위해 False 권장
+                decoded = self.msg_def.decode(bytes(msg.data), decode_choices=False, scaling=True)
             except Exception as e:
                 self._emit("decode_error", "_frame", str(e), "FAIL")
                 print(f"[FAIL] decode_error: {e}")
@@ -68,8 +92,15 @@ class DBCMonitor:
                     print(f"[FAIL] {sig}: missing in decoded")
                     continue
 
-                # bool로 강제 캐스팅(0/1), float로 오더라도 정규화
-                val = int(float(decoded[sig]))
+                # bool로 강제 캐스팅(0/1), float로 오더라도 정규화, 타입 일관성 보장
+                try:
+                    val = int(float(decoded[sig]))
+                except Exception:
+                    # 혹시라도 문자열/예외가 들어오면 방어
+                    self._emit("type_cast", sig, decoded[sig], "FAIL")
+                    print(f"[FAIL] {sig}: cannot cast value={decoded[sig]!r} to int")
+                    continue
+
                 self._check_bool_rules(sig, val, rule)
 
     # ─────────────────────────────────────────────────────────────────────────
@@ -104,7 +135,7 @@ class DBCMonitor:
         ev = {
             "type": "dbc",
             "id": self.target_id,
-            "metric": metric,   # enum | range | monotonic | decode_error | missing_signal
+            "metric": metric,   # enum | range 
             "signal": sig,
             "value": value,
             "status": status,


### PR DESCRIPTION
## 📌 PR 개요
- 0x366 Blinkmodi_02 DBC 신호 기반 모니터링 모듈 추가
- DBC와 Seed DB를 기반으로 신호 규칙을 자동으로 불러와 수신된 CAN 프레임을 디코드하고 OK/FAIL 상태를 판단

## 🔍 주요 구현 사항
- src/monitor/dbc_monitor.py 추가
    - DBCMonitor 클래스 구현
    - SocketCAN 기반 실시간 수신(pyhton-can)
    - cantools 이용 DBC 디코딩
    - 0x366 CAN ID만 필터링
    - 신호 단위로 enum, range, 단조성 검사를 수행하고 결과를 log_event()로 기록
- 로그 및 예외 처리 개선
    - 디코드 실패, 누락 신호, 타입 변환 실패 등 상황별 FAIL 이벤트 구분 기록
- Fail 판정 규칙
    - enum : 허용 값 집합 [0, 1] 내 포함 여부 확인
    - range : min <= value <= max 범위 검사 (1bit 신호는 enum과 동일 효과)
    - 단조성 검사 : 이전값과 현재값 비교 
    
## ✅ 체크리스트
- [ ]  Blinkmodi_02 (0x366) DBC 기반 실시간 모니터링 구현
- [ ]  Seed DB에서 규칙 자동 로드 (`enum`, `min/max` 기반)
- [ ]  디코드 실패 / 값 변환 예외 / 누락 신호 처리
- [ ]  콘솔 및 외부 로거(`log_event`) 동시 기록