### PR TITLE
Add: Mutator 내부 함수 구현

### DIFF
--- a/src/mutation/mutator.py
+++ b/src/mutation/mutator.py
@@ -27,34 +27,51 @@ class Mutator:
     
     def flip_bit(self) -> None:
         """랜덤 바이트 내 특정 비트를 flip"""
-        pass
+        byte_idx = self.select_random_byte()                    # ① 바이트 선택
+        bit_idx = self.select_random_bit(self.data[byte_idx])   # ② 비트 선택
+        self.data[byte_idx] ^= (1 << bit_idx)                   # ③ 선택된 비트 flip
 
     def increment_bit(self) -> None:
         """랜덤 비트를 +1"""
-        pass
+        byte_idx = self.select_random_byte()
+        bit_idx = self.select_random_bit(self.data[byte_idx])
+        mask = (1 << bit_idx)
+        if (self.data[byte_idx] & mask) == 0:  # 비트가 0이면 1로
+            self.data[byte_idx] |= mask
 
     def decrement_bit(self) -> None:
         """랜덤 비트를 -1"""
-        pass
+        byte_idx = self.select_random_byte()
+        bit_idx = self.select_random_bit(self.data[byte_idx])
+        mask = (1 << bit_idx)
+        if (self.data[byte_idx] & mask) != 0:  # 비트가 1이면 0으로
+            self.data[byte_idx] &= ~mask
 
     # -----------------------------
     # 🔹 Byte-level mutation
     # -----------------------------
     def increment_byte(self) -> None:
         """랜덤 바이트를 +1"""
-        pass
+        byte_idx = self.select_random_byte()
+        self.data[byte_idx] = (self.data[byte_idx] + 1) & 0xFF
 
     def decrement_byte(self) -> None:
         """랜덤 바이트를 -1"""
-        pass
+        byte_idx = self.select_random_byte()
+        self.data[byte_idx] = (self.data[byte_idx] - 1) & 0xFF
 
     def insert_byte(self) -> None:
         """랜덤 위치에 새로운 바이트 삽입"""
-        pass
+        insert_pos = random.randint(0, len(self.data))
+        new_val = random.randint(0, 255)
+        self.data.insert(insert_pos, new_val)
 
     def delete_byte(self) -> None:
         """랜덤 위치의 바이트 삭제"""
-        pass
+        if not self.data:
+            return
+        del_pos = self.select_random_byte()
+        del self.data[del_pos]
 
     # -----------------------------
     # 🔹 Utility selectors


### PR DESCRIPTION
## 📌 PR 개요
- Mutator 클래스의 mutation core 구현(비트·바이트 변이 함수) 및 협업용 인터페이스 규약을 추가했습니다.
- 다른 팀원이 select_* 함수와 mutate_manager() 를 구현/연동할 때 바로 붙일 수 있도록 요구사항(Contract)과 테스트 항목을 함께 문서화했습니다.

## 🔍 주요 변경 사항
- flip_bit, increment_bit, decrement_bit, increment_byte, decrement_byte, insert_byte, delete_byte 구현 (in-place, 반환값 없음).
- `requirements.txt` 생성 (`python-can`, `cantools` 등 기본 의존성 정의)

## ✅ 체크리스트
- [x] mutation.py에서 mutation 함수들이 self.data를 in-place 수정하도록 구현
- [x] flip_bit / increment_byte 등 핵심 함수의 동작 주석 및 간단 예시 추가

## ⚠️ 기타 참고 사항
- 모든 mutation 함수(flip_bit, increment_bit, decrement_bit, increment_byte, decrement_byte, insert_byte, delete_byte)는 in-place 로 self.data를 수정하며 None을 반환합니다.
- 호출자는 변이 결과를 mutator.data로 확인하면 됩니다.