### PR TITLE
Feature/mutator-바이트/비트 인덱스 선택

### DIFF
--- a/src/mutation/mutator.py
+++ b/src/mutation/mutator.py
@@ -78,11 +78,53 @@ class Mutator:
     # -----------------------------
     def select_random_byte(self) -> int:
         """mutation 대상 바이트 인덱스 선택"""
-        pass
+        n = len(self.data)
+        if n == 0:
+            raise ValueError("빈 데이터에서는 바이트를 선택할 수 없습니다.")
 
-    def select_random_bit(self, byte_value: int) -> int:
+        p = float(self.weights.get("byte_k_p", 0.3))
+        k = 1
+        while random.random() > p and k < n:
+            k += 1
+        k = min(k, max(1, n // 3))  # 상한: 전체의 1/3
+
+        ws = [float(self.weights.get(f"byte:{i}", 1.0)) for i in range(n)] # 기본 가중치
+
+        edge = float(self.weights.get("edge_bias", 0.0))
+        if edge > 0 and n >= 2:
+            ws[0] += edge
+            ws[-1] += edge
+
+        total = sum(ws)
+        if total <= 0:
+            return random.sample(range(n), k)
+        choices = random.choices(range(n), weights=ws, k=k)
+
+        return list(sorted(set(choices))) # 중복 방지: set으로 정리
+
+    def select_random_bit(self) -> int:
         """선택된 바이트 내 mutation 대상 비트 인덱스 선택"""
-        pass
+        p = float(self.weights.get("bit_k_p", 0.4))
+        k = 1
+        while random.random() > p and k < 8:
+            k += 1
+        k = min(k, 8)
 
+        # 2️⃣ 기본 가중치
+        w = [float(self.weights.get(f"bit:{b}", 1.0)) for b in range(8)]
+
+        # 3️⃣ MSB/LSB 바이어스
+        msb = float(self.weights.get("msb_bias", 0.0))
+        lsb = float(self.weights.get("lsb_bias", 0.0))
+        if msb > 0:
+            w = [wb + msb * (b / 7.0) for b, wb in enumerate(w)]
+        if lsb > 0:
+            w = [wb + lsb * ((7 - b) / 7.0) for b, wb in enumerate(w)]
+
+        total = sum(w)
+        if total <= 0:
+            return random.sample(range(8), k)
+        choices = random.choices(range(8), weights=w, k=k)
+        return list(sorted(set(choices)))
  
     


### PR DESCRIPTION
## 📌 PR 개요
- Mutator 클래스 내 Utility Selectors 추가
- 한 번의 호출로 변이 개수 및 대상 인덱스를 함께 결정하도록 기능 확장

## 🔍 주요 변경 사항
select_random_byte()
- 변이할 바이트 개수(k) 를 확률 기반으로 결정 (byte_k_p 가중치)
- 선택된 개수만큼 바이트 인덱스를 가중치 기반(random.choices)으로 선택
- edge_bias를 통해 첫/마지막 바이트에 선택 확률 가산
select_random_bit()
- 변이할 비트 개수(k)를 확률 기반으로 결정 (bit_k_p 가중치).
- msb_bias, lsb_bias로 상위/하위 비트 쏠림 조절
- bit:{b} 개별 가중치 반영 및 균등 분포 폴백 지원
- 중복된 인덱스 자동 제거(set) 및 정렬 후 반환 처리

## ✅ 체크리스트
- [x] select_random_byte() 내 개수(k) 결정 로직 추가
- [x] select_random_bit() 내 개수(k) 결정 로직 추가
- [x] edge_bias, msb_bias, lsb_bias 반영 완료
- [x] 중복 인덱스 제거 및 정렬 처리

## ⚠️ 기타 참고 사항
- 레포 클론 후 `.venv` 생성 → `pip install -r requirements.txt` → `.env.example` 복사만으로 개발 환경을 맞출 수 있습니다.