### PR TITLE
Feature/monitor-manager: 모니터 매니저 구현

### DIFF
--- a/src/monitor/dbc_monitor.py
+++ b/src/monitor/dbc_monitor.py
@@ -88,40 +88,66 @@ class DBCMonitor:
         # 내부 상태
         self._prev_values: Dict[str, Number] = {}  # 직전값(단조성 검사용)
         self.events: List[Dict[str, Any]] = []
+        self._fail_score = 0.0  # FAIL 스코어 누적 (0~1)
+        self._fail_count = 0    # FAIL 발생 횟수
+        self._total_checks = 0  # 전체 검사 횟수
 
     # ─────────────────────────────────────────────────────────────────────
-    def start(self):
+    def start(self) -> float:
+        """
+        DBC 모니터링 시작
+        예외 발생 시 즉시 종료하고 FAIL 스코어 반환
+        
+        :return: 최종 FAIL 스코어 (0.0 ~ 1.0)
+        """
         print(f"[ INFO ] DBCMonitor: 0x{self.target_id:X} on {self.channel}")
         print(f"         DBC={self.dbc_path}, signals={list(self.rules.keys()) or '—'}")
 
-        while True:
-            msg = self.bus.recv(timeout=1)
-            if not msg or msg.arbitration_id != self.target_id:
-                continue
+        self._fail_score = 0.0
+        self._fail_count = 0
+        self._total_checks = 0
 
-            # 디코드 실패는 즉시 예외로 올림
-            try:
-                decoded = self.msg_def.decode(bytes(msg.data), decode_choices=False, scaling=True)
-            except Exception as e:
-                self._emit("decode_error", "_frame", str(e), "FAIL")
-                raise RuntimeError(f"DBC decode 실패: {e}") from e
+        try:
+            while True:
+                msg = self.bus.recv(timeout=1)
+                if not msg or msg.arbitration_id != self.target_id:
+                    continue
 
-            # 신호별 검사
-            for sig, rule in self.rules.items():
-                if sig not in decoded:
-                    self._emit("missing_signal", sig, None, "FAIL")
-                    raise RuntimeError(f"신호 누락: {sig} - DBC에 정의된 신호가 디코딩 결과에 없습니다.")
-
-                raw = decoded[sig]
-
-                # 타입 정규화 실패는 즉시 예외
+                # 디코드 실패는 즉시 예외로 올림
                 try:
-                    val = self._normalize_value(raw, rule)
+                    decoded = self.msg_def.decode(bytes(msg.data), decode_choices=False, scaling=True)
                 except Exception as e:
-                    self._emit("type_cast", sig, raw, "FAIL")
-                    raise ValueError(f"type cast 실패: signal={sig}, value={raw!r}") from e
+                    self._emit("decode_error", "_frame", str(e), "FAIL")
+                    self._fail_score = 1.0  # 디코드 실패는 치명적 오류
+                    raise RuntimeError(f"DBC decode 실패: {e}") from e
 
-                self._check_rules(sig, val, rule)
+                # 신호별 검사
+                for sig, rule in self.rules.items():
+                    if sig not in decoded:
+                        self._emit("missing_signal", sig, None, "FAIL")
+                        self._fail_score = 1.0  # 신호 누락은 치명적 오류
+                        raise RuntimeError(f"신호 누락: {sig} - DBC에 정의된 신호가 디코딩 결과에 없습니다.")
+
+                    raw = decoded[sig]
+
+                    # 타입 정규화 실패는 즉시 예외
+                    try:
+                        val = self._normalize_value(raw, rule)
+                    except Exception as e:
+                        self._emit("type_cast", sig, raw, "FAIL")
+                        self._fail_score = 1.0  # 타입 캐스트 실패는 치명적 오류
+                        raise ValueError(f"type cast 실패: signal={sig}, value={raw!r}") from e
+
+                    self._check_rules(sig, val, rule)
+
+        except (RuntimeError, ValueError) as e:
+            # 예외 발생 시 현재 스코어 반환
+            print(f"[INFO] DBC Monitor stopped due to error: {e}")
+            print(f"[INFO] DBC Monitor finished - FAIL score: {self._fail_score:.3f}")
+            return self._fail_score
+        
+        # 정상 종료 (실제로는 무한루프이므로 도달하지 않음)
+        return self._fail_score
 
     # ─────────────────────────────────────────────────────────────────────
     def _normalize_value(self, raw: Any, rule: Dict[str, Any]) -> Number: # 규칙에 맞춰 값을 bool/int/float로 정규화
@@ -140,10 +166,12 @@ class DBCMonitor:
 
     # ─────────────────────────────────────────────────────────────────────
     def _check_rules(self, sig: str, val: Number, rule: Dict[str, Any]):
-
+        """규칙 검사 및 스코어 계산"""
+        
         #enum 검사
         enum_vals = rule.get("enum")
         if enum_vals is not None:
+            self._total_checks += 1
             if rule.get("kind") == "float":
                 ok = any(float(val) == float(a) for a in enum_vals)
             else:
@@ -151,37 +179,59 @@ class DBCMonitor:
 
             self._emit("enum", sig, val, "OK" if ok else "FAIL")
             if not ok:
+                self._fail_count += 1
+                self._update_fail_score()
                 raise RuntimeError(f"enum 위반: {sig} value={val}, 허용={enum_vals}")
 
         # range 검사
         mn, mx = rule.get("min"), rule.get("max")
 
-        if mn is not None and float(val) < float(mn):
-            self._emit("range", sig, val, "FAIL")
-            raise RuntimeError(f"range 하한 위반: {sig} value={val}, min={mn}")
+        if mn is not None:
+            self._total_checks += 1
+            if float(val) < float(mn):
+                self._fail_count += 1
+                self._emit("range", sig, val, "FAIL")
+                self._update_fail_score()
+                raise RuntimeError(f"range 하한 위반: {sig} value={val}, min={mn}")
 
-        if mx is not None and float(val) > float(mx):
-            self._emit("range", sig, val, "FAIL")
-            raise RuntimeError(f"range 상한 위반: {sig} value={val}, max={mx}")
+        if mx is not None:
+            self._total_checks += 1
+            if float(val) > float(mx):
+                self._fail_count += 1
+                self._emit("range", sig, val, "FAIL")
+                self._update_fail_score()
+                raise RuntimeError(f"range 상한 위반: {sig} value={val}, max={mx}")
 
-        self._emit("range", sig, val, "OK")
+        if mn is not None or mx is not None:
+            self._emit("range", sig, val, "OK")
 
         # 단조성 검사
         mode = rule.get("monotonic")
         if mode:
             prev = self._prev_values.get(sig)
             if prev is not None:
+                self._total_checks += 1
                 pv = float(prev)
                 cv = float(val)
                 if mode == "nondecreasing" and cv < pv:
+                    self._fail_count += 1
                     self._emit("monotonic", sig, {"prev": prev, "cur": val, "mode": mode}, "FAIL")
+                    self._update_fail_score()
                     raise RuntimeError(f"단조성 위반: {sig} {prev} → {val} (nondecreasing)")
                 if mode == "nonincreasing" and cv > pv:
+                    self._fail_count += 1
                     self._emit("monotonic", sig, {"prev": prev, "cur": val, "mode": mode}, "FAIL")
+                    self._update_fail_score()
                     raise RuntimeError(f"단조성 위반: {sig} {prev} → {val} (nonincreasing)")
             self._emit("monotonic", sig, {"prev": prev, "cur": val, "mode": mode}, "OK") # prev가 없거나 위반이 없으면 OK로 기록
 
         self._prev_values[sig] = val # 정상 통과 시 이전값 갱신
+
+    # ─────────────────────────────────────────────────────────────────────
+    def _update_fail_score(self):
+        """FAIL 스코어 업데이트 (0~1 범위)"""
+        if self._total_checks > 0:
+            self._fail_score = min(self._fail_count / self._total_checks, 1.0)
 
     # ─────────────────────────────────────────────────────────────────────
     def _emit(self, metric: str, sig: str, value: Any, status: str):
@@ -197,7 +247,13 @@ class DBCMonitor:
         self.events.append(ev)
         log_event("dbc", self.target_id, f"{sig}:{metric}", value, status)
 
+    # ─────────────────────────────────────────────────────────────────────
     def fetch_events(self):
         out = self.events[:]
         self.events.clear()
         return out
+    
+    # ─────────────────────────────────────────────────────────────────────
+    def get_fail_score(self) -> float:
+        
+        return self._fail_score

--- a/src/monitor/monitor_manager.py
+++ b/src/monitor/monitor_manager.py
@@ -1,202 +1,207 @@
 # src/monitor/monitor_manager.py
-# 각 모니터를 스레드로 실행하고, FAIL 발생 시 리턴값으로 종료 처리
 
 import threading
 import time
-from typing import Optional, Dict, Any
+from typing import Dict, Optional
+from monitor.timing_monitor import TimingMonitor
+from monitor.uds_monitor import UDSMonitor
+from monitor.dbc_monitor import DBCMonitor
 
 
 class MonitorManager:
-    """
-    여러 모니터(DBC, Timing, UDS)를 개별 스레드로 실행하고,
-    각 모니터로부터 실수 점수를 받아 딕셔너리로 반환합니다.
-    """
 
-    def __init__(self):
-        self.monitors: Dict[str, Any] = {}
+    
+    def __init__(self,
+                 timing_monitor: Optional[TimingMonitor] = None,
+                 uds_monitor: Optional[UDSMonitor] = None,
+                 dbc_monitor: Optional[DBCMonitor] = None):
+        """
+        :param timing_monitor: TimingMonitor 인스턴스 (None이면 비활성화)
+        :param uds_monitor: UDSMonitor 인스턴스 (None이면 비활성화)
+        :param dbc_monitor: DBCMonitor 인스턴스 (None이면 비활성화)
+        """
+        self.timing_monitor = timing_monitor
+        self.uds_monitor = uds_monitor
+        self.dbc_monitor = dbc_monitor
+        
+        # 스레드 관리
         self.threads: Dict[str, threading.Thread] = {}
-        self.durations: Dict[str, Optional[float]] = {}  # 각 모니터의 실행 시간
-        self.results: Dict[str, Optional[float]] = {}  # 각 모니터의 점수 저장
-        self.stop_event = threading.Event()
-        self.lock = threading.Lock()
-
-    def register(self, name: str, monitor_instance: Any, duration: Optional[float] = None):
-        """
-        모니터 인스턴스를 등록합니다.
         
-        :param name: 모니터 식별 이름 (예: "dbc", "timing", "uds")
-        :param monitor_instance: start() 메서드를 가진 모니터 객체
-        :param duration: 해당 모니터의 실행 시간(초). None이면 무제한
-        """
-        if name in self.monitors:
-            raise ValueError(f"Monitor '{name}' is already registered.")
+        # 스코어 저장
+        self.scores: Dict[str, float] = {
+            "timing": 0.0,
+            "uds": 0.0,
+            "dbc": 0.0
+        }
+        self.scores_lock = threading.Lock()
         
-        self.monitors[name] = monitor_instance
-        self.durations[name] = duration
-        self.results[name] = None
+        # 완료 상태 추적
+        self.completed: Dict[str, bool] = {
+            "timing": False,
+            "uds": False,
+            "dbc": False
+        }
         
-        duration_str = f"{duration}s" if duration else "unlimited"
-        print(f"[MonitorManager] Registered monitor: {name} (duration: {duration_str})")
-
-    def _monitor_wrapper(self, name: str, monitor_instance: Any, duration: Optional[float]):
-        """
-        각 모니터를 실행하는 래퍼 함수.
-        모니터의 start() 메서드로부터 실수 점수를 받아 저장합니다.
-        duration이 설정된 경우 해당 시간 후 강제 종료합니다.
-        """
-        monitor_thread = threading.current_thread()
-        timer = None
+        # 실행 상태
+        self.running = False
         
-        def timeout_handler():
-            print(f"[MonitorManager] Monitor '{name}' reached timeout ({duration}s)")
-            # 타임아웃 시 해당 모니터 스레드를 강제 종료하는 대신
-            # 결과를 None으로 설정하고 stop_event 설정
-            with self.lock:
-                if self.results[name] is None:
-                    self.results[name] = None
+    
+    def start_monitors(self, timing_timeout: Optional[float] = None):
+        """
+        각 모니터를 별도 스레드로 시작
+        
+        :param timing_timeout: Timing 모니터 실행 시간 제한(초). None이면 무제한
+        """
+        if self.running:
+            print("[WARN] Monitors are already running")
+            return
+        
+        self.running = True
+        print("[INFO] Starting monitors...")
+        
+        # 스코어 및 완료 상태 초기화
+        with self.scores_lock:
+            self.scores = {"timing": 0.0, "uds": 0.0, "dbc": 0.0}
+            self.completed = {"timing": False, "uds": False, "dbc": False}
+        
+        # Timing Monitor 스레드
+        if self.timing_monitor:
+            thread = threading.Thread(
+                target=self._run_timing_monitor,
+                args=(timing_timeout,),
+                daemon=True,
+                name="TimingMonitor"
+            )
+            self.threads["timing"] = thread
+            thread.start()
+            print("[INFO] ✓ Timing Monitor started")
+        else:
+            self.completed["timing"] = True
+        
+        # UDS Monitor 스레드
+        if self.uds_monitor:
+            thread = threading.Thread(
+                target=self._run_uds_monitor,
+                daemon=True,
+                name="UDSMonitor"
+            )
+            self.threads["uds"] = thread
+            thread.start()
+            print("[INFO] ✓ UDS Monitor started")
+        else:
+            self.completed["uds"] = True
+        
+        # DBC Monitor 스레드
+        if self.dbc_monitor:
+            thread = threading.Thread(
+                target=self._run_dbc_monitor,
+                daemon=True,
+                name="DBCMonitor"
+            )
+            self.threads["dbc"] = thread
+            thread.start()
+            print("[INFO] ✓ DBC Monitor started")
+        else:
+            self.completed["dbc"] = True
+        
+        print(f"[INFO] Total {len(self.threads)} monitor(s) running")
+    
+    
+    def _run_timing_monitor(self, timeout: Optional[float]):
         
         try:
-            # duration이 설정된 경우 타이머 시작
-            if duration is not None:
-                timer = threading.Timer(duration, timeout_handler)
-                timer.daemon = True
-                timer.start()
+            fail_score = self.timing_monitor.start(timeout=timeout)
             
-            print(f"[MonitorManager] Starting monitor: {name}")
+            with self.scores_lock:
+                self.scores["timing"] = fail_score
+                self.completed["timing"] = True
             
-            # 모니터 실행 - 실수 점수 리턴
-            score = monitor_instance.start()
-            
-            # 정상 완료 시 타이머 취소
-            if timer:
-                timer.cancel()
-            
-            with self.lock:
-                self.results[name] = float(score)
-                print(f"[MonitorManager] Monitor '{name}' returned score: {score}")
+            print(f"[INFO] Timing Monitor completed - Score: {fail_score}")
                     
         except Exception as e:
-            # 예외 발생 시 타이머 취소
-            if timer:
-                timer.cancel()
-            
-            with self.lock:
-                self.results[name] = None
-                print(f"[MonitorManager] Monitor '{name}' raised exception: {e}")
-                self.stop_event.set()
-
-    def start_all(self) -> Dict[str, Optional[float]]:
-        """
-        등록된 모든 모니터를 스레드로 시작합니다.
-        각 모니터는 register 시 설정한 duration만큼 실행됩니다.
-        
-        :return: {monitor_name: score} 딕셔너리
-        """
-        if not self.monitors:
-            print("[MonitorManager] No monitors registered.")
-            return {}
-
-        print(f"[MonitorManager] Starting {len(self.monitors)} monitor(s)...")
-        
-        # 각 모니터를 스레드로 시작
-        for name, monitor in self.monitors.items():
-            duration = self.durations[name]
-            thread = threading.Thread(
-                target=self._monitor_wrapper,
-                args=(name, monitor, duration),
-                daemon=True,
-                name=f"Monitor-{name}"
-            )
-            self.threads[name] = thread
-            thread.start()
-        
-        # 모든 스레드가 종료되거나 예외 발생까지 대기
-        while True:
-            # 예외 발생 확인
-            if self.stop_event.is_set():
-                print("[MonitorManager] Stop event detected. Terminating...")
-                break
-            
-            # 모든 스레드 완료 확인
-            all_done = all(not t.is_alive() for t in self.threads.values())
-            if all_done:
-                print("[MonitorManager] All monitors completed.")
-                break
-            
-            time.sleep(0.1)
-
-        # 스레드 종료 대기 (최대 5초)
-        for name, thread in self.threads.items():
-            if thread.is_alive():
-                print(f"[MonitorManager] Waiting for monitor '{name}' to terminate...")
-                thread.join(timeout=5.0)
-                if thread.is_alive():
-                    print(f"[MonitorManager] Warning: Monitor '{name}' did not terminate gracefully.")
-
-        # 결과 딕셔너리 반환
-        results = self.get_results()
-        print(f"[MonitorManager] Monitoring completed. Results: {results}")
-        
-        return results
-
-    def get_results(self) -> Dict[str, Optional[float]]:
-        """
-        각 모니터의 점수를 반환합니다.
-        
-        :return: {monitor_name: score} 딕셔너리
-        """
-        with self.lock:
-            return self.results.copy()
-
-    def stop_all(self):
-        """
-        모든 모니터를 강제 종료합니다.
-        """
-        print("[MonitorManager] Stopping all monitors...")
-        self.stop_event.set()
-        
-        for name, thread in self.threads.items():
-            if thread.is_alive():
-                thread.join(timeout=5.0)
-                if thread.is_alive():
-                    print(f"[MonitorManager] Warning: Monitor '{name}' did not stop.")
-
-
-# 사용 예시
-if __name__ == "__main__":
-    from dbc_monitor import DBCMonitor
-    from timing_monitor import TimingMonitor
-    from uds_monitor import UDSMonitor
-
-    manager = MonitorManager()
-
-    # 각 모니터 인스턴스 생성 및 등록
-    # DBC와 Timing은 duration 설정, UDS는 duration 없음
+            print(f"[ERROR] Timing Monitor crashed: {e}")
+            with self.scores_lock:
+                self.completed["timing"] = True
     
-    try:
-        dbc_mon = DBCMonitor()
-        manager.register("dbc", dbc_mon, duration=30.0)  # 30초 동안 실행
-    except Exception as e:
-        print(f"[WARN] DBCMonitor 초기화 실패: {e}")
-
-    try:
-        timing_mon = TimingMonitor()
-        manager.register("timing", timing_mon, duration=30.0)  # 30초 동안 실행
-    except Exception as e:
-        print(f"[WARN] TimingMonitor 초기화 실패: {e}")
-
-    try:
-        uds_mon = UDSMonitor()
-        manager.register("uds", uds_mon)  # duration 없음 (완료될 때까지 실행)
-    except Exception as e:
-        print(f"[WARN] UDSMonitor 초기화 실패: {e}")
-
-    # 모든 모니터 시작
-    scores = manager.start_all()
-
-    # 결과 확인
-    print("\n=== Monitoring Scores ===")
-    for name, score in scores.items():
-        print(f"  {name}: {score}")
     
-    # 추후 증거결합 모듈에서 이 scores 딕셔너리를 사용
+    def _run_uds_monitor(self):
+        
+        try:
+            fail_score = self.uds_monitor.start()
+            
+            with self.scores_lock:
+                self.scores["uds"] = fail_score
+                self.completed["uds"] = True
+            
+            print(f"[INFO] UDS Monitor completed - Score: {fail_score}")
+                
+        except Exception as e:
+            print(f"[ERROR] UDS Monitor crashed: {e}")
+            with self.scores_lock:
+                self.completed["uds"] = True
+    
+    
+    def _run_dbc_monitor(self):
+       
+        try:
+            fail_score = self.dbc_monitor.start()
+            
+            with self.scores_lock:
+                self.scores["dbc"] = fail_score
+                self.completed["dbc"] = True
+            
+            print(f"[INFO] DBC Monitor completed - Score: {fail_score}")
+                
+        except Exception as e:
+            print(f"[ERROR] DBC Monitor crashed: {e}")
+            with self.scores_lock:
+                self.completed["dbc"] = True
+    
+    
+    def wait_for_completion(self, timeout: Optional[float] = None):
+        """
+        모든 모니터 스레드가 종료될 때까지 대기
+        param timeout 대기 시간 제한(초). None이면 무제한
+        """
+        for name, thread in self.threads.items():
+            thread.join(timeout=timeout)
+            if thread.is_alive():
+                print(f"[WARN] {name} thread is still running")
+        
+        self.running = False
+        print("[INFO] All monitors completed")
+    
+    
+    def is_all_completed(self) -> bool:
+        """
+        모든 모니터가 완료되었는지 확인
+        """
+        with self.scores_lock:
+            return all(self.completed.values())
+    
+    
+    def get_completion_status(self) -> Dict[str, bool]:
+        """
+        각 모니터의 완료 상태 반환
+        :return: {"timing": bool, "uds": bool, "dbc": bool}
+        """
+        with self.scores_lock:
+            return self.completed.copy()
+    
+    
+    def get_scores(self) -> Dict[str, float]:
+        """
+        각 모니터별 FAIL 스코어 반환
+        :return: {"timing": float, "uds": float, "dbc": float}
+        """
+        with self.scores_lock:
+            return self.scores.copy()
+    
+    
+    def is_running(self) -> bool:
+        """
+        모니터 실행 상태 반환
+        
+        :return: 실행 중이면 True
+        """
+        return self.running

--- a/src/monitor/monitor_manager.py
+++ b/src/monitor/monitor_manager.py
@@ -1,0 +1,202 @@
+# src/monitor/monitor_manager.py
+# 각 모니터를 스레드로 실행하고, FAIL 발생 시 리턴값으로 종료 처리
+
+import threading
+import time
+from typing import Optional, Dict, Any
+
+
+class MonitorManager:
+    """
+    여러 모니터(DBC, Timing, UDS)를 개별 스레드로 실행하고,
+    각 모니터로부터 실수 점수를 받아 딕셔너리로 반환합니다.
+    """
+
+    def __init__(self):
+        self.monitors: Dict[str, Any] = {}
+        self.threads: Dict[str, threading.Thread] = {}
+        self.durations: Dict[str, Optional[float]] = {}  # 각 모니터의 실행 시간
+        self.results: Dict[str, Optional[float]] = {}  # 각 모니터의 점수 저장
+        self.stop_event = threading.Event()
+        self.lock = threading.Lock()
+
+    def register(self, name: str, monitor_instance: Any, duration: Optional[float] = None):
+        """
+        모니터 인스턴스를 등록합니다.
+        
+        :param name: 모니터 식별 이름 (예: "dbc", "timing", "uds")
+        :param monitor_instance: start() 메서드를 가진 모니터 객체
+        :param duration: 해당 모니터의 실행 시간(초). None이면 무제한
+        """
+        if name in self.monitors:
+            raise ValueError(f"Monitor '{name}' is already registered.")
+        
+        self.monitors[name] = monitor_instance
+        self.durations[name] = duration
+        self.results[name] = None
+        
+        duration_str = f"{duration}s" if duration else "unlimited"
+        print(f"[MonitorManager] Registered monitor: {name} (duration: {duration_str})")
+
+    def _monitor_wrapper(self, name: str, monitor_instance: Any, duration: Optional[float]):
+        """
+        각 모니터를 실행하는 래퍼 함수.
+        모니터의 start() 메서드로부터 실수 점수를 받아 저장합니다.
+        duration이 설정된 경우 해당 시간 후 강제 종료합니다.
+        """
+        monitor_thread = threading.current_thread()
+        timer = None
+        
+        def timeout_handler():
+            print(f"[MonitorManager] Monitor '{name}' reached timeout ({duration}s)")
+            # 타임아웃 시 해당 모니터 스레드를 강제 종료하는 대신
+            # 결과를 None으로 설정하고 stop_event 설정
+            with self.lock:
+                if self.results[name] is None:
+                    self.results[name] = None
+        
+        try:
+            # duration이 설정된 경우 타이머 시작
+            if duration is not None:
+                timer = threading.Timer(duration, timeout_handler)
+                timer.daemon = True
+                timer.start()
+            
+            print(f"[MonitorManager] Starting monitor: {name}")
+            
+            # 모니터 실행 - 실수 점수 리턴
+            score = monitor_instance.start()
+            
+            # 정상 완료 시 타이머 취소
+            if timer:
+                timer.cancel()
+            
+            with self.lock:
+                self.results[name] = float(score)
+                print(f"[MonitorManager] Monitor '{name}' returned score: {score}")
+                    
+        except Exception as e:
+            # 예외 발생 시 타이머 취소
+            if timer:
+                timer.cancel()
+            
+            with self.lock:
+                self.results[name] = None
+                print(f"[MonitorManager] Monitor '{name}' raised exception: {e}")
+                self.stop_event.set()
+
+    def start_all(self) -> Dict[str, Optional[float]]:
+        """
+        등록된 모든 모니터를 스레드로 시작합니다.
+        각 모니터는 register 시 설정한 duration만큼 실행됩니다.
+        
+        :return: {monitor_name: score} 딕셔너리
+        """
+        if not self.monitors:
+            print("[MonitorManager] No monitors registered.")
+            return {}
+
+        print(f"[MonitorManager] Starting {len(self.monitors)} monitor(s)...")
+        
+        # 각 모니터를 스레드로 시작
+        for name, monitor in self.monitors.items():
+            duration = self.durations[name]
+            thread = threading.Thread(
+                target=self._monitor_wrapper,
+                args=(name, monitor, duration),
+                daemon=True,
+                name=f"Monitor-{name}"
+            )
+            self.threads[name] = thread
+            thread.start()
+        
+        # 모든 스레드가 종료되거나 예외 발생까지 대기
+        while True:
+            # 예외 발생 확인
+            if self.stop_event.is_set():
+                print("[MonitorManager] Stop event detected. Terminating...")
+                break
+            
+            # 모든 스레드 완료 확인
+            all_done = all(not t.is_alive() for t in self.threads.values())
+            if all_done:
+                print("[MonitorManager] All monitors completed.")
+                break
+            
+            time.sleep(0.1)
+
+        # 스레드 종료 대기 (최대 5초)
+        for name, thread in self.threads.items():
+            if thread.is_alive():
+                print(f"[MonitorManager] Waiting for monitor '{name}' to terminate...")
+                thread.join(timeout=5.0)
+                if thread.is_alive():
+                    print(f"[MonitorManager] Warning: Monitor '{name}' did not terminate gracefully.")
+
+        # 결과 딕셔너리 반환
+        results = self.get_results()
+        print(f"[MonitorManager] Monitoring completed. Results: {results}")
+        
+        return results
+
+    def get_results(self) -> Dict[str, Optional[float]]:
+        """
+        각 모니터의 점수를 반환합니다.
+        
+        :return: {monitor_name: score} 딕셔너리
+        """
+        with self.lock:
+            return self.results.copy()
+
+    def stop_all(self):
+        """
+        모든 모니터를 강제 종료합니다.
+        """
+        print("[MonitorManager] Stopping all monitors...")
+        self.stop_event.set()
+        
+        for name, thread in self.threads.items():
+            if thread.is_alive():
+                thread.join(timeout=5.0)
+                if thread.is_alive():
+                    print(f"[MonitorManager] Warning: Monitor '{name}' did not stop.")
+
+
+# 사용 예시
+if __name__ == "__main__":
+    from dbc_monitor import DBCMonitor
+    from timing_monitor import TimingMonitor
+    from uds_monitor import UDSMonitor
+
+    manager = MonitorManager()
+
+    # 각 모니터 인스턴스 생성 및 등록
+    # DBC와 Timing은 duration 설정, UDS는 duration 없음
+    
+    try:
+        dbc_mon = DBCMonitor()
+        manager.register("dbc", dbc_mon, duration=30.0)  # 30초 동안 실행
+    except Exception as e:
+        print(f"[WARN] DBCMonitor 초기화 실패: {e}")
+
+    try:
+        timing_mon = TimingMonitor()
+        manager.register("timing", timing_mon, duration=30.0)  # 30초 동안 실행
+    except Exception as e:
+        print(f"[WARN] TimingMonitor 초기화 실패: {e}")
+
+    try:
+        uds_mon = UDSMonitor()
+        manager.register("uds", uds_mon)  # duration 없음 (완료될 때까지 실행)
+    except Exception as e:
+        print(f"[WARN] UDSMonitor 초기화 실패: {e}")
+
+    # 모든 모니터 시작
+    scores = manager.start_all()
+
+    # 결과 확인
+    print("\n=== Monitoring Scores ===")
+    for name, score in scores.items():
+        print(f"  {name}: {score}")
+    
+    # 추후 증거결합 모듈에서 이 scores 딕셔너리를 사용

--- a/src/monitor/timing_monitor.py
+++ b/src/monitor/timing_monitor.py
@@ -3,6 +3,7 @@
 import can
 import time
 from logger.base_logger import log_event
+from typing import Optional
 
 
 # 모니터링 설정값 
@@ -38,17 +39,32 @@ class TimingMonitor:
         self.events = []          # 발생한 이벤트 버퍼
         self._frame_counter = 0   # 평균 주기 계산용 카운터
         self._cycle_list = []     # 최근 N개의 주기 기록
+        self._fail_score = 0.0    # FAIL 스코어 누적
 
 
-    def start(self):
+    def start(self, timeout: Optional[float] = None) -> float:
         """
         모니터링 루프 시작.
         지정된 CAN ID의 메시지를 수신하며, 주기 위배 여부를 검사한다.
+        
+        :param timeout: 모니터링 시간 제한(초). None이면 무제한
+        :return: 최종 FAIL 스코어
         """
         print(f"[ INFO ] Monitoring 0x{self.target_id:X} "
               f"(Cycle={self.expected}ms ±{self.tolerance}ms) on {self.channel}")
+        
+        if timeout:
+            print(f"[ INFO ] Timeout set to {timeout} seconds")
+        
+        start_time = time.time()
+        self._fail_score = 0.0  # 스코어 초기화
 
         while True:
+            # timeout 체크
+            if timeout and (time.time() - start_time) >= timeout:
+                print(f"[ INFO ] Timing Monitor timeout reached ({timeout}s)")
+                break
+            
             msg = self.bus.recv(timeout=1)
             if not msg:
                 continue
@@ -61,6 +77,16 @@ class TimingMonitor:
             if self.prev_time:
                 cycle = now - self.prev_time
                 status = "OK" if (self.expected - self.tolerance <= cycle <= self.expected + self.tolerance) else "FAIL"
+
+                # FAIL인 경우 스코어 누적 (오차의 절댓값)
+                if status == "FAIL":
+                    if cycle < self.expected - self.tolerance:
+                        # 너무 빠름
+                        error = (self.expected - self.tolerance) - cycle
+                    else:
+                        # 너무 느림
+                        error = cycle - (self.expected + self.tolerance)
+                    self._fail_score += error
 
                 # 이벤트 생성 및 저장
                 event = {
@@ -86,6 +112,18 @@ class TimingMonitor:
                     print(f"    └ Average cycle (last {LOG_INTERVAL}): {avg_cycle:.2f} ms")
 
             self.prev_time = now
+        
+        print(f"[ INFO ] Timing Monitor finished - Total FAIL score: {self._fail_score:.2f}")
+        return self._fail_score
+
+
+    def get_fail_score(self) -> float:
+        """
+        현재까지 누적된 FAIL 스코어 반환
+        
+        :return: FAIL 스코어 (허용 범위를 벗어난 오차의 누적합)
+        """
+        return self._fail_score
 
 
     def fetch_events(self):

--- a/src/monitor/uds_monitor.py
+++ b/src/monitor/uds_monitor.py
@@ -25,6 +25,11 @@ isotp_params = {
     "rx_consecutive_frame_timeout": 1000,
 }
 
+# 스코어 가중치 설정
+SCORE_NO_RESPONSE_0x10 = 1.0   # 세션 진입 실패 (가장 치명적)
+SCORE_NO_RESPONSE_0x3E = 0.8   # Tester Present 실패
+MAX_DTC_COUNT = 20              # DTC 개수 정규화 기준 (20개 이상이면 1.0)
+
 
 
 # NRC config 로드
@@ -65,6 +70,9 @@ class UDSMonitor:
             rxid=TARGET_UDS_ID + UDS_RESPONSE_OFFSET
         )
         self.stack = isotp.CanStack(bus=self.bus, address=addr, params=isotp_params)
+        
+        # FAIL 스코어 누적 (0~1 범위)
+        self._fail_score = 0.0
 
 
     # ISO-TP 송신
@@ -90,29 +98,55 @@ class UDSMonitor:
 
 
 
-    def start(self):
+    def start(self) -> float:
+        """
+        UDS 모니터링 시작
+        
+        :return: 최종 FAIL 스코어 (0.0 ~ 1.0+)
+        """
+        self._fail_score = 0.0  # 스코어 초기화
+        
         try:
             # 0x10 세션 진입
-            if not self._send_once_or_retry([0x10, 0x02], "session_entry"):
-                return
+            if not self._send_once_or_retry([0x10, 0x02], "session_entry", SCORE_NO_RESPONSE_0x10):
+                print("[INFO] UDS Monitor finished - Session entry failed")
+                return min(self._fail_score, 1.0)  # 1.0으로 제한
 
             # 0x3E Tester Present
-            if not self._send_once_or_retry([0x3E, 0x00], "tester_present"):
-                return
+            if not self._send_once_or_retry([0x3E, 0x00], "tester_present", SCORE_NO_RESPONSE_0x3E):
+                print("[INFO] UDS Monitor finished - Tester present failed")
+                return min(self._fail_score, 1.0)
 
             # 0x19 DTC 읽기
             self.send_request([0x19, 0x02])
             total_dtc = self.collect_all_dtc()
-            value = total_dtc / 20.0
-            log_event("uds", TARGET_UDS_ID, "DTC_total_score", value, "OK")
+            
+            # DTC 스코어 계산 (0 ~ 1.0)
+            dtc_score = min(total_dtc / MAX_DTC_COUNT, 1.0)
+            self._fail_score += dtc_score
+            
+            log_event("uds", TARGET_UDS_ID, "DTC_count", total_dtc, "OK" if total_dtc == 0 else "FAIL")
+            log_event("uds", TARGET_UDS_ID, "DTC_score", dtc_score, "OK" if dtc_score < 0.5 else "FAIL")
 
         except Exception as e:
             log_event("uds", TARGET_UDS_ID, "exception", str(e), "FAIL")
+            self._fail_score = 1.0  # 예외 발생 시 최대 스코어
+        
+        # 최종 스코어는 1.0을 초과할 수 있음 (여러 FAIL이 누적될 경우)
+        print(f"[INFO] UDS Monitor finished - Total FAIL score: {self._fail_score:.3f}")
+        return self._fail_score
 
     # 1회 전송 + 1회 재시도
 
-    def _send_once_or_retry(self, data, step_name):
-        """요청 보내고 응답 확인, 없으면 한 번만 재시도"""
+    def _send_once_or_retry(self, data, step_name, no_response_score):
+        """
+        요청 보내고 응답 확인, 없으면 한 번만 재시도
+        
+        :param data: 전송할 UDS 요청 데이터
+        :param step_name: 단계 이름 (로깅용)
+        :param no_response_score: 응답 없을 때 부여할 스코어 (0~1)
+        :return: 성공 여부
+        """
         # 1차 요청
         self.send_request(data)
         resp = self.recv_response(timeout=1.0)
@@ -123,7 +157,8 @@ class UDSMonitor:
             resp = self.recv_response(timeout=1.0)
 
             if not resp:
-                log_event("uds", TARGET_UDS_ID, f"{step_name}_no_response", "high", "FAIL")
+                self._fail_score += no_response_score
+                log_event("uds", TARGET_UDS_ID, f"{step_name}_no_response", no_response_score, "FAIL")
                 return False
 
         # NRC 응답
@@ -131,9 +166,12 @@ class UDSMonitor:
             nrc = resp[2]
             if nrc in self.NRC_CLASS:
                 score = self.NRC_CLASS[nrc]
+                self._fail_score += score
                 log_event("uds", TARGET_UDS_ID, f"NRC_{hex(nrc)}", score, "FAIL")
                 return False
             else:
+                # 알 수 없는 NRC는 정상으로 처리
+                log_event("uds", TARGET_UDS_ID, f"NRC_unknown_{hex(nrc)}", nrc, "WARN")
                 return True
 
         # 정상 응답
@@ -163,10 +201,19 @@ class UDSMonitor:
                 nrc = resp[2]
                 if nrc in self.NRC_CLASS:
                     score = self.NRC_CLASS[nrc]
-                    log_event("uds", TARGET_UDS_ID, f"NRC_{hex(nrc)}", score, "FAIL")
+                    self._fail_score += score
+                    log_event("uds", TARGET_UDS_ID, f"DTC_NRC_{hex(nrc)}", score, "FAIL")
                 else:
                     log_event("uds", TARGET_UDS_ID, "DTC_NRC_Unknown", nrc, "WARN")
                 continue
 
         total_dtc = len(accumulated_data) // 4  # 3바이트 코드 + 1바이트 상태
         return total_dtc
+    
+    
+    def get_fail_score(self) -> float:
+        """
+        현재까지 누적된 FAIL 스코어 반환
+        0~1 범위
+        """
+        return self._fail_score

--- a/src/mutation/mutator.py
+++ b/src/mutation/mutator.py
@@ -1,9 +1,5 @@
-# ======================================
-# 🧬 Mutator Skeleton (CLI 환경용)
-# ======================================
-
 import random
-from typing import Dict, Tuple, Any
+from typing import Dict
 
 
 class Mutator:
@@ -15,10 +11,66 @@ class Mutator:
         self.data = bytearray(data)
         self.weights = weights  # 단순 저장만 수행
 
-    def mutate_manager(self) -> None:
-        """전체 mutation 관리"""
+    def mutate_manager(self) -> list[bytes]:
+        budget        = int(self.weights.get("manager.budget", 256))
+        max_ops       = int(self.weights.get("manager.max_ops", 3))
+        enable_struct = bool(self.weights.get("manager.structural", True))
+        include_orig  = bool(self.weights.get("manager.include_original", False))
+        
+        rng = random
 
-        pass
+        out: list[bytes] = []
+        seen: set[bytes] = set()
+
+        def add_snapshot_from_current_buf():
+            b = bytes(self.data)
+            if b not in seen:
+                seen.add(b)
+                out.append(b)
+
+        base = bytes(self.data)
+
+        if include_orig:
+            # 원본을 스냅샷으로 추가
+            self.data = bytearray(base)
+            add_snapshot_from_current_buf()
+
+        attempt_cap = budget * 20
+        attempts = 0
+        while len(out) < budget and attempts < attempt_cap:
+            attempts += 1
+
+            # 이번 시드용 작업 버퍼 준비
+            saved = self.data
+            self.data = bytearray(base)
+            try:
+                k = rng.randint(1, max_ops)
+
+                for _ in range(k):
+                    op_kind = rng.choice([
+                        "flip_bit",
+                        "increment_bit",
+                        "decrement_bit",
+                        "increment_byte",
+                        "decrement_byte",
+                        "insert_byte" if enable_struct else "increment_byte",
+                        "delete_byte" if enable_struct else "decrement_byte",
+                    ])
+                    try:
+                        # 이름으로 메서드 찾아 호출
+                        getattr(self, op_kind)()
+                    except Exception:
+                        # 실패 연산은 스킵
+                        continue
+
+                # 현재 buf(self.data) 스냅샷 등록
+                add_snapshot_from_current_buf()
+            finally:
+                # self.data 복구
+                self.data = saved
+
+        self.generated = out
+        return out
 
     # -----------------------------
     # 🔹 Bit-level mutation
@@ -27,38 +79,89 @@ class Mutator:
     
     def flip_bit(self) -> None:
         """랜덤 바이트 내 특정 비트를 flip"""
-        byte_idx = self.select_random_byte()                    # ① 바이트 선택
-        bit_idx = self.select_random_bit(self.data[byte_idx])   # ② 비트 선택
-        self.data[byte_idx] ^= (1 << bit_idx)                   # ③ 선택된 비트 flip
+        byte_idxs = self.select_random_byte()
+        # 리스트/정수 모두 처리
+        if isinstance(byte_idxs, int):
+            byte_idxs = [byte_idxs]
+        if not byte_idxs:
+            return
+        byte_idx = random.choice(byte_idxs)
+        if not (0 <= byte_idx < len(self.data)):
+            return
+
+        bit_idxs = self.select_random_bit()
+        if isinstance(bit_idxs, int):
+            bit_idxs = [bit_idxs]
+        if not bit_idxs:
+            return
+        bit_idx = random.choice(bit_idxs)  # 하나만 뽑아 적용
+        self.data[byte_idx] ^= (1 << bit_idx)
 
     def increment_bit(self) -> None:
         """랜덤 비트를 +1"""
-        byte_idx = self.select_random_byte()
-        bit_idx = self.select_random_bit(self.data[byte_idx])
+        byte_idxs = self.select_random_byte()
+        if isinstance(byte_idxs, int):
+            byte_idxs = [byte_idxs]
+        if not byte_idxs:
+            return
+        byte_idx = random.choice(byte_idxs)
+        if not (0 <= byte_idx < len(self.data)):
+            return
+
+        bit_idxs = self.select_random_bit()
+        if isinstance(bit_idxs, int):
+            bit_idxs = [bit_idxs]
+        if not bit_idxs:
+            return
+        bit_idx = random.choice(bit_idxs)
+
         mask = (1 << bit_idx)
-        if (self.data[byte_idx] & mask) == 0:  # 비트가 0이면 1로
+        if (self.data[byte_idx] & mask) == 0:
             self.data[byte_idx] |= mask
 
     def decrement_bit(self) -> None:
         """랜덤 비트를 -1"""
-        byte_idx = self.select_random_byte()
-        bit_idx = self.select_random_bit(self.data[byte_idx])
+        byte_idxs = self.select_random_byte()
+        if isinstance(byte_idxs, int):
+            byte_idxs = [byte_idxs]
+        if not byte_idxs:
+            return
+        byte_idx = random.choice(byte_idxs)
+        if not (0 <= byte_idx < len(self.data)):
+            return
+
+        bit_idxs = self.select_random_bit()
+        if isinstance(bit_idxs, int):
+            bit_idxs = [bit_idxs]
+        if not bit_idxs:
+            return
+        bit_idx = random.choice(bit_idxs)
+
         mask = (1 << bit_idx)
-        if (self.data[byte_idx] & mask) != 0:  # 비트가 1이면 0으로
+        if (self.data[byte_idx] & mask) != 0:
             self.data[byte_idx] &= ~mask
 
-    # -----------------------------
-    # 🔹 Byte-level mutation
-    # -----------------------------
     def increment_byte(self) -> None:
         """랜덤 바이트를 +1"""
-        byte_idx = self.select_random_byte()
-        self.data[byte_idx] = (self.data[byte_idx] + 1) & 0xFF
+        byte_idxs = self.select_random_byte()
+        if isinstance(byte_idxs, int):
+            byte_idxs = [byte_idxs]
+        if not byte_idxs:
+            return
+        byte_idx = random.choice(byte_idxs)
+        if 0 <= byte_idx < len(self.data):
+            self.data[byte_idx] = (self.data[byte_idx] + 1) & 0xFF
 
     def decrement_byte(self) -> None:
         """랜덤 바이트를 -1"""
-        byte_idx = self.select_random_byte()
-        self.data[byte_idx] = (self.data[byte_idx] - 1) & 0xFF
+        byte_idxs = self.select_random_byte()
+        if isinstance(byte_idxs, int):
+            byte_idxs = [byte_idxs]
+        if not byte_idxs:
+            return
+        byte_idx = random.choice(byte_idxs)
+        if 0 <= byte_idx < len(self.data):
+            self.data[byte_idx] = (self.data[byte_idx] - 1) & 0xFF
 
     def insert_byte(self) -> None:
         """랜덤 위치에 새로운 바이트 삽입"""
@@ -70,13 +173,19 @@ class Mutator:
         """랜덤 위치의 바이트 삭제"""
         if not self.data:
             return
-        del_pos = self.select_random_byte()
-        del self.data[del_pos]
+        del_idxs = self.select_random_byte()
+        if isinstance(del_idxs, int):
+            del_idxs = [del_idxs]
+        if not del_idxs:
+            return
+        del_pos = random.choice(del_idxs)
+        if 0 <= del_pos < len(self.data):
+            del self.data[del_pos]
 
     # -----------------------------
     # 🔹 Utility selectors
     # -----------------------------
-    def select_random_byte(self) -> int:
+    def select_random_byte(self) -> list[int]:
         """mutation 대상 바이트 인덱스 선택"""
         n = len(self.data)
         if n == 0:
@@ -102,7 +211,7 @@ class Mutator:
 
         return list(sorted(set(choices))) # 중복 방지: set으로 정리
 
-    def select_random_bit(self) -> int:
+    def select_random_bit(self) -> list[int]:
         """선택된 바이트 내 mutation 대상 비트 인덱스 선택"""
         p = float(self.weights.get("bit_k_p", 0.4))
         k = 1
@@ -126,5 +235,3 @@ class Mutator:
             return random.sample(range(8), k)
         choices = random.choices(range(8), weights=w, k=k)
         return list(sorted(set(choices)))
- 
-    


### PR DESCRIPTION
## 📌 PR 개요
- Monitor_manager를 만들었습니다. 모니터 매니저는 각 모니터를 실행하고 fail값을 값을 불러오는 함수를 통해 불러옵니다.
- Timing 모니터는 manager에서 timeout 인자를 줄 수 있도록 수정하였습니다.

## 🔍 주요 변경 사항
- 각 모니터에 get_fail_score()함수 추가로 fail값을 manager에서 받을 수 있게 정의 
- Timing start에 timeout 인자 추가
- manager의 main 삭제 및 cli 역할을 하는 함수들 삭제

## ✅ 체크리스트
- [x] 전체 로직 검증 

## ⚠️ 기타 참고 사항