### PR TITLE
Feature/monitor-manager-integration: MonitorManager 연동 및 pipeline 모니터링 흐름 추가

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -1,4 +1,5 @@
 # src/cli.py
+import json
 import click
 from pipeline import AutoFuzzPipeline
 
@@ -8,28 +9,25 @@ def cli():
     """Auto-Fuzz CLI — Seed registration, listing, and fuzzing."""
     pass
 
-
-# 1. 시드 등록
+# 시드 등록
 @cli.command()
-@click.option("--dbc", required=True, type=click.Path(exists=True), help="Path to DBC file.")
-@click.option("--db", default="seeds.db", help="SQLite DB file path.")
+@click.option("--dbc", required=True, type=click.Path(exists=True))
+@click.option("--db", default="seeds.db")
 def register(dbc, db):
-    """Register seeds from a DBC file into the database."""
-    click.echo(f"[+] Parsing DBC file: {dbc}")
+    click.echo(f"[+] Parsing DBC: {dbc}")
     count = AutoFuzzPipeline.register_seeds(dbc, db)
     click.echo(f"[✓] {count} seeds registered into '{db}'")
 
 
-
-# 2. 시드 목록 보기
+# 시드 목록 출력
 @cli.command()
-@click.option("--db", default="seeds.db", help="SQLite DB file path.")
+@click.option("--db", default="seeds.db")
 def list(db):
-    """List all registered seeds."""
     seeds = AutoFuzzPipeline.list_seeds(db)
     if not seeds:
         click.echo("[!] No seeds found.")
         return
+
     click.echo(f"[+] {len(seeds)} seeds loaded:")
     click.echo("-" * 60)
     for s in seeds:
@@ -37,32 +35,69 @@ def list(db):
     click.echo("-" * 60)
 
 
+# Monitor 결과 출력
+def print_monitor_results(results: dict):
+    click.echo(click.style("\n=== AutoFuzz Monitor Results ===\n", fg="cyan", bold=True))
 
-# 3. 퍼징 실행
+    for name, v in results.items():
+        monitor = name.upper()
+
+        # 상태 색상 + 아이콘
+        if v["completed"]:
+            status_icon = click.style("✓", fg="green")
+            status_text = click.style("completed", fg="green")
+        else:
+            status_icon = click.style("✗", fg="red")
+            status_text = click.style("timeout", fg="red")
+
+        # 점수 색상
+        score = click.style(f"{v['score']:.3f}", fg="cyan")
+
+        click.echo(
+            f"{status_icon} {click.style(monitor, bold=True):<10} "
+            f"Score: {score}  ({status_text})"
+        )
+        
+    click.echo()
+
+
+# 퍼저 실행
 @cli.command()
-@click.option("--db", default="seeds.db", help="SQLite DB file path.")
-@click.option("--channel", default="vcan0", help="CAN channel (default: vcan0)")
-@click.option("--can", is_flag=True, help="Enable actual CAN interface (otherwise stub mode).")
-@click.option("--can-id", default="0x6A6", help="CAN ID (hex string, default: 0x6A6)")
-def run(db, channel, can, can_id):
+@click.option("--db", default="seeds.db")
+@click.option("--channel", default="vcan0")
+@click.option("--can", is_flag=True)
+@click.option("--can-id", default="0x6A6")
+@click.option("--save-json", is_flag=True, help="Save monitor results to fuzz_results.json")
+def run(db, channel, can, can_id, save_json):
     """Run Auto-Fuzz pipeline."""
+
+    # CAN ID 파싱
     try:
         can_id_int = int(can_id, 16)
-        click.echo(f"[✓] Using CAN ID {hex(can_id_int)} (Tx/Rx)")
+        click.echo(f"[✓] Using CAN ID {hex(can_id_int)}")
     except ValueError:
-        click.echo("[!] Invalid CAN ID format. Use hex like 0x6A6.")
+        click.echo("[!] Invalid CAN ID format.")
         return
 
+    # 인터페이스 준비
     can_iface = None
     if can:
         from interface.can_interface import CANInterface
         can_iface = CANInterface(channel=channel, can_id=can_id_int)
-        click.echo(f"[+] CAN Interface initialized on '{channel}' (ID={hex(can_id_int)})")
-        click.echo("    • Seeds with message_id will use that ID for sending.")
-        click.echo("    • Others will use this default fallback ID.")
+        click.echo(f"[+] CAN Interface initialized on {channel}")
 
+    # 파이프라인 실행
     pipeline = AutoFuzzPipeline(db, can_iface=can_iface)
-    pipeline.run()
+    results = pipeline.run()
+
+    # 모니터 결과 출력
+    print_monitor_results(results)
+
+    # JSON 저장 옵션
+    if save_json:
+        with open("fuzz_results.json", "w", encoding="utf-8") as f:
+            json.dump(results, f, indent=4)
+        click.echo(click.style("[✓] Results saved → fuzz_results.json", fg="green"))
 
 
 if __name__ == "__main__":

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -1,15 +1,19 @@
 # src/pipeline.py
 import time
+import json
+from typing import Optional, Dict, Any
+
 from seeds.dbc_parser import DbcParser
 from seeds.seed_manager import SeedManager, Seed
 from seeds.seed_queue import SeedQueue
-from typing import Optional
+
+from monitor.monitor_manager import MonitorManager
+from monitor.timing_monitor import TimingMonitor
+from monitor.uds_monitor import UDSMonitor
+from monitor.dbc_monitor import DBCMonitor
 
 
 class AutoFuzzPipeline:
-    """Seed DB 기반 CAN 송신 파이프라인"""
-
-    # Seed 등록 및 조회
     @staticmethod
     def register_seeds(dbc_path: str, db_path: str = "seeds.db") -> int:
         parser = DbcParser(dbc_path)
@@ -35,20 +39,18 @@ class AutoFuzzPipeline:
         manager.close()
         return seeds
 
-
-    # 초기화 및 송신
     def __init__(self, db_path: str = "seeds.db", can_iface: Optional[object] = None):
-        """
-        db_path: Seed DB 경로
-        can_iface: CLI에서 전달받은 CANInterface (없으면 stub 모드)
-         = CLI에서 --can 옵션을 주지 않는 경우, 터미널 출력만 보이는 stub 모드
-        """
         self.queue = SeedQueue(db_path)
         self.can = can_iface
         self.running = False
 
+        self.monitor_manager = MonitorManager(
+            timing_monitor=TimingMonitor(),
+            uds_monitor=UDSMonitor(),
+            dbc_monitor=DBCMonitor()
+        )
+
     def send(self, seed: Seed):
-        """Seed를 CAN으로 송신 (seed.message_id 우선, 없으면 fallback)"""
         if not self.can:
             arb = seed.message_id or 0x6A6
             print(f"[Stub:Tx] ID={hex(arb)} | Signal={seed.signal_name:<25}")
@@ -67,30 +69,47 @@ class AutoFuzzPipeline:
         except Exception as e:
             print(f"[!] CAN send error: {e}")
 
-
-    # 실행 루프
-    def run(self):
-        """Seed 큐 순회하며 송신"""
+    def run(self) -> Dict[str, Any]:
+        """
+        퍼징 + 모니터링을 수행하고 최종 결과 딕셔너리로 반환한다.
+        CLI 쪽에서 출력/저장하도록 함.
+        """
         self.running = True
-        print("[+] Auto-Fuzz pipeline started (mutation/monitor disabled).")
 
+        # 모니터 실행
+        self.monitor_manager.start_monitors(timing_timeout=5.0)
+
+        # CAN Listener 시작
         if self.can:
             try:
                 self.can.start_listener()
             except Exception as e:
                 print(f"[!] CAN listener start failed: {e}")
 
+        # Fuzzing Loop
         while self.running:
             seed = self.queue.pop()
             if not seed:
-                print("[!] No more seeds. Stopping.")
                 break
 
             self.send(seed)
             time.sleep(0.2)
 
+        # 종료 처리
         if self.can:
             self.can.stop_listener()
 
-        print("[✓] Fuzzing complete.")
+        self.monitor_manager.wait_for_completion()
+
+        scores = self.monitor_manager.get_scores()
+        status = self.monitor_manager.get_completion_status()
+
+        # 파이프라인 종료
         self.queue.close()
+
+        # 결과 딕셔너리 리턴
+        return {
+            "timing": {"score": scores["timing"], "completed": status["timing"]},
+            "uds": {"score": scores["uds"], "completed": status["uds"]},
+            "dbc": {"score": scores["dbc"], "completed": status["dbc"]},
+        }


### PR DESCRIPTION
## 📌 PR 개요
> 기존 단일 송신 루프 형태에서 **“모니터 시작 → fuzzing → 모니터 종료 → 결과 수집”** 구조로 Pipeline 구조 확장


## 🔍 주요 변경 사항
### ✔️ `pipeline.py`
- MonitorManager 인스턴스를 자동으로 생성하여 run()에서 실행 흐름 통합
- Fuzzing 시작 전 모니터 실행 → 종료 후 결과 출력 구조로 재편
- 모니터 점수 출력 및 완료 상태 표시 기능 추가
- 전체 CAN fuzzing 파이프라인과 실시간 모니터링을 자연스럽게 연결

### ✔️ `cli.py`
- pipeline 실행 시 모니터 시스템이 자동으로 포함되도록 구조 수정
- CLI 흐름에서 모니터링 옵션 및 구조 정합성 검증

### ✔️ 실행 결과 예시 (CLI)
```
=== AutoFuzz Monitor Results ===

✓ TIMING     Score: 0.912  (completed)
✓ UDS        Score: 0.573  (completed)
✗ DBC        Score: 0.104  (timeout)
```


## 🧪 체크리스트
- [x] 스코어 및 completion 상태 정상 수집 확인
- [ ] CLI → Pipeline → MonitorManager 전체 흐름 검증 완료


## ⚠️ 기타 참고 사항
- 모니터가 crash하거나 timeout 발생 시도 fail 값은 manager에서 자동 저장
- 병렬 구조 특성상 로그 순서가 뒤섞일 수 있으며 이후 logging 모듈 도입으로 개선 가능  
- 향후 PR에서 모니터 fail 발생 시 fuzzing 자동 중단 기능도 추가 가능