### PR TITLE
Feature/monitor refact : DBC Timeout 추가, monitor_manager에 Timing timeout 추가 

### DIFF
--- a/src/monitor/dbc_monitor.py
+++ b/src/monitor/dbc_monitor.py
@@ -93,61 +93,78 @@ class DBCMonitor:
         self._total_checks = 0  # 전체 검사 횟수
 
     # ─────────────────────────────────────────────────────────────────────
-    def start(self) -> float:
-        """
-        DBC 모니터링 시작
-        예외 발생 시 즉시 종료하고 FAIL 스코어 반환
-        
-        :return: 최종 FAIL 스코어 (0.0 ~ 1.0)
-        """
-        print(f"[ INFO ] DBCMonitor: 0x{self.target_id:X} on {self.channel}")
-        print(f"         DBC={self.dbc_path}, signals={list(self.rules.keys()) or '—'}")
+    def start(self, timeout: Optional[float] = None) -> float:
+    """
+    DBC 모니터링 시작
+    예외 발생 시 즉시 종료하고 FAIL 스코어 반환
+    timeout이 설정되면 해당 시간(초) 동안만 실행 후 정상 종료
 
-        self._fail_score = 0.0
-        self._fail_count = 0
-        self._total_checks = 0
+    :param timeout: 최대 실행 시간(초). None이면 무제한 실행
+    :return: 최종 FAIL 스코어 (0.0 ~ 1.0)
+    """
+    print(f"[ INFO ] DBCMonitor: 0x{self.target_id:X} on {self.channel}")
+    print(f"         DBC={self.dbc_path}, signals={list(self.rules.keys()) or '—'}")
 
-        try:
-            while True:
-                msg = self.bus.recv(timeout=1)
-                if not msg or msg.arbitration_id != self.target_id:
-                    continue
+    self._fail_score = 0.0
+    self._fail_count = 0
+    self._total_checks = 0
 
-                # 디코드 실패는 즉시 예외로 올림
+    start_time = time.time()
+
+    try:
+        while True:
+
+            # ───── timeout 검사 ─────
+            if timeout is not None:
+                if (time.time() - start_time) >= timeout:
+                    print(f"[INFO] DBC Monitor timeout reached ({timeout}s)")
+                    break
+
+            msg = self.bus.recv(timeout=1)
+            if not msg or msg.arbitration_id != self.target_id:
+                continue
+
+            # 디코드 시도
+            try:
+                decoded = self.msg_def.decode(
+                    bytes(msg.data),
+                    decode_choices=False,
+                    scaling=True
+                )
+            except Exception as e:
+                self._emit("decode_error", "_frame", str(e), "FAIL")
+                self._fail_score = 1.0
+                raise RuntimeError(f"DBC decode 실패: {e}") from e
+
+            # 신호 규칙 검사
+            for sig, rule in self.rules.items():
+                if sig not in decoded:
+                    self._emit("missing_signal", sig, None, "FAIL")
+                    self._fail_score = 1.0
+                    raise RuntimeError(f"신호 누락: {sig}")
+
+                raw = decoded[sig]
+
                 try:
-                    decoded = self.msg_def.decode(bytes(msg.data), decode_choices=False, scaling=True)
+                    val = self._normalize_value(raw, rule)
                 except Exception as e:
-                    self._emit("decode_error", "_frame", str(e), "FAIL")
-                    self._fail_score = 1.0  # 디코드 실패는 치명적 오류
-                    raise RuntimeError(f"DBC decode 실패: {e}") from e
+                    self._emit("type_cast", sig, raw, "FAIL")
+                    self._fail_score = 1.0
+                    raise ValueError(
+                        f"type cast 실패: signal={sig}, value={raw!r}"
+                    ) from e
 
-                # 신호별 검사
-                for sig, rule in self.rules.items():
-                    if sig not in decoded:
-                        self._emit("missing_signal", sig, None, "FAIL")
-                        self._fail_score = 1.0  # 신호 누락은 치명적 오류
-                        raise RuntimeError(f"신호 누락: {sig} - DBC에 정의된 신호가 디코딩 결과에 없습니다.")
+                self._check_rules(sig, val, rule)
 
-                    raw = decoded[sig]
-
-                    # 타입 정규화 실패는 즉시 예외
-                    try:
-                        val = self._normalize_value(raw, rule)
-                    except Exception as e:
-                        self._emit("type_cast", sig, raw, "FAIL")
-                        self._fail_score = 1.0  # 타입 캐스트 실패는 치명적 오류
-                        raise ValueError(f"type cast 실패: signal={sig}, value={raw!r}") from e
-
-                    self._check_rules(sig, val, rule)
-
-        except (RuntimeError, ValueError) as e:
-            # 예외 발생 시 현재 스코어 반환
-            print(f"[INFO] DBC Monitor stopped due to error: {e}")
-            print(f"[INFO] DBC Monitor finished - FAIL score: {self._fail_score:.3f}")
-            return self._fail_score
-        
-        # 정상 종료 (실제로는 무한루프이므로 도달하지 않음)
+    except (RuntimeError, ValueError) as e:
+        # 예외 발생 → FAIL 스코어 반환
+        print(f"[INFO] DBC Monitor stopped due to error: {e}")
+        print(f"[INFO] DBC Monitor finished - FAIL score: {self._fail_score:.3f}")
         return self._fail_score
+
+    # timeout 혹은 정상 종료
+    print(f"[INFO] DBC Monitor finished - FAIL score: {self._fail_score:.3f}")
+    return self._fail_score
 
     # ─────────────────────────────────────────────────────────────────────
     def _normalize_value(self, raw: Any, rule: Dict[str, Any]) -> Number: # 규칙에 맞춰 값을 bool/int/float로 정규화

--- a/src/monitor/monitor_manager.py
+++ b/src/monitor/monitor_manager.py
@@ -46,65 +46,69 @@ class MonitorManager:
         self.running = False
         
     
-    def start_monitors(self, timing_timeout: Optional[float] = None):
-        """
-        각 모니터를 별도 스레드로 시작
-        
-        :param timing_timeout: Timing 모니터 실행 시간 제한(초). None이면 무제한
-        """
-        if self.running:
-            print("[WARN] Monitors are already running")
-            return
-        
-        self.running = True
-        print("[INFO] Starting monitors...")
-        
-        # 스코어 및 완료 상태 초기화
-        with self.scores_lock:
-            self.scores = {"timing": 0.0, "uds": 0.0, "dbc": 0.0}
-            self.completed = {"timing": False, "uds": False, "dbc": False}
-        
-        # Timing Monitor 스레드
-        if self.timing_monitor:
-            thread = threading.Thread(
-                target=self._run_timing_monitor,
-                args=(timing_timeout,),
-                daemon=True,
-                name="TimingMonitor"
-            )
-            self.threads["timing"] = thread
-            thread.start()
-            print("[INFO] ✓ Timing Monitor started")
-        else:
-            self.completed["timing"] = True
-        
-        # UDS Monitor 스레드
-        if self.uds_monitor:
-            thread = threading.Thread(
-                target=self._run_uds_monitor,
-                daemon=True,
-                name="UDSMonitor"
-            )
-            self.threads["uds"] = thread
-            thread.start()
-            print("[INFO] ✓ UDS Monitor started")
-        else:
-            self.completed["uds"] = True
-        
-        # DBC Monitor 스레드
-        if self.dbc_monitor:
-            thread = threading.Thread(
-                target=self._run_dbc_monitor,
-                daemon=True,
-                name="DBCMonitor"
-            )
-            self.threads["dbc"] = thread
-            thread.start()
-            print("[INFO] ✓ DBC Monitor started")
-        else:
-            self.completed["dbc"] = True
-        
-        print(f"[INFO] Total {len(self.threads)} monitor(s) running")
+    def start_monitors(self, 
+                   timing_timeout: Optional[float] = 5.0,
+                   dbc_timeout: Optional[float] = 5.0):
+    """
+    각 모니터를 별도 스레드로 시작
+
+    :param timing_timeout: Timing 모니터 실행 시간 제한(초). 기본 5초
+    :param dbc_timeout: DBC 모니터 실행 시간 제한(초). 기본 5초
+    """
+    if self.running:
+        print("[WARN] Monitors are already running")
+        return
+    
+    self.running = True
+    print("[INFO] Starting monitors...")
+    
+    # 스코어 및 완료 상태 초기화
+    with self.scores_lock:
+        self.scores = {"timing": 0.0, "uds": 0.0, "dbc": 0.0}
+        self.completed = {"timing": False, "uds": False, "dbc": False}
+    
+    # Timing Monitor 스레드
+    if self.timing_monitor:
+        thread = threading.Thread(
+            target=self._run_timing_monitor,
+            args=(timing_timeout,),
+            daemon=True,
+            name="TimingMonitor"
+        )
+        self.threads["timing"] = thread
+        thread.start()
+        print("[INFO] ✓ Timing Monitor started")
+    else:
+        self.completed["timing"] = True
+
+    # UDS Monitor 스레드
+    if self.uds_monitor:
+        thread = threading.Thread(
+            target=self._run_uds_monitor,
+            daemon=True,
+            name="UDSMonitor"
+        )
+        self.threads["uds"] = thread
+        thread.start()
+        print("[INFO] ✓ UDS Monitor started")
+    else:
+        self.completed["uds"] = True
+
+    # DBC Monitor 스레드 (timeout 추가됨)
+    if self.dbc_monitor:
+        thread = threading.Thread(
+            target=self._run_dbc_monitor,
+            args=(dbc_timeout,),
+            daemon=True,
+            name="DBCMonitor"
+        )
+        self.threads["dbc"] = thread
+        thread.start()
+        print("[INFO] ✓ DBC Monitor started")
+    else:
+        self.completed["dbc"] = True
+
+    print(f"[INFO] Total {len(self.threads)} monitor(s) running")
     
     
     def _run_timing_monitor(self, timeout: Optional[float]):
@@ -141,21 +145,20 @@ class MonitorManager:
                 self.completed["uds"] = True
     
     
-    def _run_dbc_monitor(self):
-       
-        try:
-            fail_score = self.dbc_monitor.start()
-            
-            with self.scores_lock:
-                self.scores["dbc"] = fail_score
-                self.completed["dbc"] = True
-            
-            print(f"[INFO] DBC Monitor completed - Score: {fail_score}")
+    def _run_dbc_monitor(self, timeout: Optional[float]):
+    try:
+        fail_score = self.dbc_monitor.start(timeout=timeout)
+
+        with self.scores_lock:
+            self.scores["dbc"] = fail_score
+            self.completed["dbc"] = True
+
+        print(f"[INFO] DBC Monitor completed - Score: {fail_score}")
                 
-        except Exception as e:
-            print(f"[ERROR] DBC Monitor crashed: {e}")
-            with self.scores_lock:
-                self.completed["dbc"] = True
+    except Exception as e:
+        print(f"[ERROR] DBC Monitor crashed: {e}")
+        with self.scores_lock:
+            self.completed["dbc"] = True
     
     
     def wait_for_completion(self, timeout: Optional[float] = None):


### PR DESCRIPTION
## 📌 PR 개요
- dbc_monitor timeout 추가
- Timing_monitor timeout 기본값 none에서 5초로 변경

## 🔍 주요 변경 사항
- dbc_monitor 인자로 time을 받아 그 시간 만큼만 실행되도록 수정
- Timing_monitor 기본 값을 무제한에서 5초로 수정

## ✅ 체크리스트
- [x] Timing_monitor 정규화 과정 필요(0~1)

