### PR TITLE
Feature/UDS_monitor: UDS 모니터에 0x78 Response Pending 대기 로직 추가

### DIFF
--- a/src/monitor/uds_monitor.py
+++ b/src/monitor/uds_monitor.py
@@ -1,0 +1,200 @@
+from dataclasses import dataclass
+from typing import List, Tuple, Dict, Optional, Callable
+import time
+
+@dataclass
+class UDSEvent:
+    service: str               
+    response_type: str           
+    code: Optional[int]
+    raw: bytes
+    timestamp: float
+
+class ISOTPAssembler:
+    def __init__(self):
+        self.buffer = bytearray()
+        self.expected_len = 0
+        self.next_sn = 1
+        self.in_progress = False
+
+    def feed(self, data: bytes) -> Optional[bytes]:
+        if not data:
+            return None
+
+        pci_type = (data[0] & 0xF0) >> 4
+        pci_low  =  data[0] & 0x0F
+
+        # SF: Single Frame (<=7 data bytes)
+        if pci_type == 0x0:
+            length = pci_low
+            return data[1:1 + length]
+
+        # FF: First Frame
+        elif pci_type == 0x1:
+            self.expected_len = ((pci_low << 8) | data[1])
+            self.buffer = bytearray(data[2:])
+            self.in_progress = True
+            self.next_sn = 1
+            return None  # wait for CFs
+
+        # CF: Consecutive Frame
+        elif pci_type == 0x2 and self.in_progress:
+            sn = pci_low
+            # sequence check
+            if sn != (self.next_sn & 0x0F):
+                self.reset()
+                return None
+            self.next_sn += 1
+            self.buffer.extend(data[1:])
+            if len(self.buffer) >= self.expected_len:
+                pdu = bytes(self.buffer[:self.expected_len])
+                self.reset()
+                return pdu
+            return None
+
+        # FC: Flow Control (0x3) → ignore (receiver side)
+        else:
+            return None
+
+    def reset(self):
+        self.buffer = bytearray()
+        self.expected_len = 0
+        self.next_sn = 1
+        self.in_progress = False
+
+
+class UDSMonitor:
+    """
+    - send_0x10 / send_0x3e: 단일프레임 송신 + 응답 대기/분류
+    - probe_session_then_tester_present: 0x10 긍정이면 0x3E 연속 수행
+    """
+    def __init__(
+        self,
+        tx_id: int = 0x7E0,
+        rx_id: int = 0x7E8,
+        sender: Optional[Callable[[int, bytes], None]] = None,
+        collector: Optional[Callable[[float], List[Tuple[int, bytes, float]]]] = None,
+    ):
+        self.tx_id = tx_id
+        self.rx_id = rx_id
+        self.sender = sender          
+        self.collector = collector    
+        self.assembler = ISOTPAssembler()
+
+    # -------------------------
+    # Parse UDS response (positive/negative만 생성)
+    # -------------------------
+    @staticmethod
+    def parse_uds_pdu(pdu: bytes) -> Optional["UDSEvent"]:
+        # Negative Response (0x7F <req_service> <NRC>)
+        if len(pdu) >= 3 and pdu[0] == 0x7F:
+            req_srv, nrc = pdu[1], pdu[2]
+            return UDSEvent(f"0x{req_srv:02X}", "negative", nrc, pdu, time.time())
+
+        # Positive Response (0x40 + <req_service>)
+        if len(pdu) >= 1 and pdu[0] >= 0x40:
+            service = pdu[0] - 0x40
+            return UDSEvent(f"0x{service:02X}", "positive", None, pdu, time.time())
+
+        # 그 외는 이벤트 생성 안 함
+        return None
+
+    @staticmethod
+    def _build_sf_from_uds_pdu(uds_pdu: bytes) -> bytes:
+        """
+        UDS PDU (<=7 bytes)를 ISO-TP Single Frame로 캡슐화해 8바이트 반환.
+        """
+        if len(uds_pdu) > 7:
+            raise ValueError("PDU too long for Single Frame")
+        pad_len = 7 - len(uds_pdu)
+        return bytes([len(uds_pdu)]) + uds_pdu + bytes(pad_len)
+
+    def _wait_one_uds_event(
+        self,
+        expected_service: int,
+        timeout: float = 1.0,
+        poll_interval: float = 0.02,
+    ) -> Optional[UDSEvent]:
+        """
+        collector를 폴링하여 응답 하나를 조립 완료될 때까지 기다리고 반환.
+        expected_service와 매칭되는 positive/negative만 리턴.
+        """
+        if not self.collector:
+            return None
+
+        t0 = time.time()
+        last_ts = t0
+        while time.time() - t0 < timeout:
+            frames = self.collector(last_ts)  
+            if frames:
+                last_ts = max(last_ts, max(ts for _, _, ts in frames))
+            for arbid, data, ts in frames:
+                if arbid != self.rx_id:
+                    continue
+                pdu = self.assembler.feed(data)
+                if pdu is None:
+                    continue
+                evt = self.parse_uds_pdu(pdu)
+                if evt is not None:
+                    evt.timestamp = ts
+                    # positive: 0x40+expected_service
+                    # negative: 0x7F,<expected_service>,<NRC>
+                    if evt.service.lower() == f"0x{expected_service:02x}":
+                        return evt
+            time.sleep(poll_interval)
+
+        return None  # timeout
+
+    # -------------------------
+    # Send 0x10 & wait response
+    # -------------------------
+    def send_0x10(self, subfunc: int = 0x01, timeout: float = 1.0) -> Optional[UDSEvent]:
+        if not self.sender:
+            raise RuntimeError("sender is not set")
+        uds_pdu = bytes([0x10, subfunc])
+        can_data = self._build_sf_from_uds_pdu(uds_pdu)
+        self.sender(self.tx_id, can_data)
+        return self._wait_one_uds_event(expected_service=0x10, timeout=timeout)
+
+    # -------------------------
+    # Send 0x3E & wait response
+    # -------------------------
+    def send_0x3e(self, subfunc: int = 0x00, timeout: float = 1.0) -> Optional[UDSEvent]:
+        if not self.sender:
+            raise RuntimeError("sender is not set")
+        uds_pdu = bytes([0x3E, subfunc])
+        can_data = self._build_sf_from_uds_pdu(uds_pdu)
+        self.sender(self.tx_id, can_data)
+        return self._wait_one_uds_event(expected_service=0x3E, timeout=timeout)
+
+    # -------------------------
+    # Sequence: 0x10 → (positive) 0x3E
+    # -------------------------
+    def probe_session_then_tester_present(
+        self,
+        session_sub: int = 0x01,
+        tester_sub: int = 0x00,
+        t1: float = 1.0,
+        t2: float = 1.0,
+    ) -> Dict[str, Optional[UDSEvent]]:
+        """
+        1) 0x10 세션 전환 요청 → 응답 분류
+        2) positive면 0x3E tester present → 응답 분류
+        """
+        result: Dict[str, Optional[UDSEvent]] = {"0x10": None, "0x3E": None}
+        evt10 = self.send_0x10(session_sub, timeout=t1)
+        result["0x10"] = evt10
+
+        if evt10 and evt10.response_type == "positive":
+            evt3e = self.send_0x3e(tester_sub, timeout=t2)
+            result["0x3E"] = evt3e
+
+        return result
+
+    # -------------------------
+    # Simple print helper (optional)
+    # -------------------------
+    def interpret(self, events: List[UDSEvent]) -> None:
+        print("UDS Monitor Events:")
+        for e in events:
+            print(f"  [{e.timestamp:.3f}] {e.service:<6} {e.response_type:<9} {e.code or '-'} {e.raw.hex().upper()}")

--- a/src/monitor/uds_monitor.py
+++ b/src/monitor/uds_monitor.py
@@ -1,16 +1,21 @@
-from dataclasses import dataclass
-from typing import Optional, Dict, Tuple
-import time, os
+# src/monitor/uds_monitor.py
+import time
+import os
 import can
 import isotp
 import yaml
+from logger.base_logger import log_event
 
-CAN_CHANNEL         = "can0"
-TARGET_UDS_ID       = 0x366
-UDS_RESPONSE_OFFSET = 0x6A                 # 응답 ID = TARGET_UDS_ID + 0x6A
-PADDING_BYTE        = 0xAA                 # ISO-TP TX 패딩 바이트
 
-_ISOTP_PARAMS = {
+# 모니터링 설정값
+
+CAN_CHANNEL = "can0"
+TARGET_UDS_ID = 0x366
+UDS_RESPONSE_OFFSET = 0x6A
+PADDING_BYTE = 0xAA
+
+# ISO-TP 기본 설정
+isotp_params = {
     "stmin": 0,
     "blocksize": 8,
     "wftmax": 0,
@@ -20,175 +25,199 @@ _ISOTP_PARAMS = {
     "rx_consecutive_frame_timeout": 1000,
 }
 
-def load_nrc_config_strict(path: str) -> Tuple[Dict[int, float], Dict[str, float]]:
-    """
-    엄격 모드:
-      - 파일/필드/형식이 틀리면 즉시 예외
-      - nrc_scores: 키는 반드시 '0x..' 16진 문자열 → int로 변환
-      - context_multipliers: 키는 반드시 '0x..' 소문자 16진 문자열
-    """
-    if not path or not os.path.exists(path):
-        raise FileNotFoundError(f"UDSMonitor config not found: {path}")
+# 스코어 가중치 설정
+SCORE_NO_RESPONSE_0x10 = 1.0   # 세션 진입 실패 (가장 치명적)
+SCORE_NO_RESPONSE_0x3E = 0.8   # Tester Present 실패
+MAX_DTC_COUNT = 20              # DTC 개수 정규화 기준 (20개 이상이면 1.0)
+
+
+
+# NRC config 로드
+
+def load_nrc_config(path: str):
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"NRC config not found: {path}")
 
     with open(path, "r", encoding="utf-8") as f:
         data = yaml.safe_load(f)
 
-    if not isinstance(data, dict):
-        raise ValueError("Config YAML root must be a mapping")
+    if not isinstance(data, dict) or "nrc_scores" not in data:
+        raise ValueError("Invalid NRC config: missing 'nrc_scores'")
 
-    if "nrc_scores" not in data or "context_multipliers" not in data:
-        raise KeyError("Config must contain both 'nrc_scores' and 'context_multipliers'")
-
-    raw_scores = data["nrc_scores"]
-    raw_ctx    = data["context_multipliers"]
-
-    if not isinstance(raw_scores, dict) or not isinstance(raw_ctx, dict):
-        raise ValueError("'nrc_scores' and 'context_multipliers' must be mappings")
-
-    # nrc_scores: '0x..' 문자열 → int 키
-    nrc_scores: Dict[int, float] = {}
-    for k, v in raw_scores.items():
-        if not isinstance(k, str) or not k.strip().lower().startswith("0x"):
-            raise ValueError(f"NRC key must be hex string like '0x10', got {k!r}")
+    scores = {}
+    for k, v in data["nrc_scores"].items():
         try:
-            ki = int(k.strip().lower(), 16)
-            vf = float(v)
+            key = int(k, 16) if isinstance(k, str) and k.startswith("0x") else int(k)
+            scores[key] = float(v)
         except Exception as e:
-            raise ValueError(f"Invalid nrc_scores entry {k!r}:{v!r} → {e}")
-        nrc_scores[ki] = vf
-
-    # context_multipliers: '0x..' 소문자 16진 문자열
-    ctx_mul: Dict[str, float] = {}
-    for k, v in raw_ctx.items():
-        if not isinstance(k, str):
-            raise ValueError(f"Context key must be string like '0x10', got {type(k)}")
-        ks = k.strip().lower()
-        if not ks.startswith("0x"):
-            raise ValueError(f"Context key must start with '0x': {k!r}")
-        try:
-            int(ks, 16)  # 유효성 확인
-            vf = float(v)
-        except Exception as e:
-            raise ValueError(f"Invalid context_multipliers entry {k!r}:{v!r} → {e}")
-        ctx_mul[ks] = vf
-
-    if not nrc_scores:
-        raise ValueError("'nrc_scores' must not be empty")
-    if not ctx_mul:
-        raise ValueError("'context_multipliers' must not be empty")
-
-    return nrc_scores, ctx_mul
+            raise ValueError(f"Invalid NRC key/value {k}:{v} ({e})")
+    return scores
 
 
-@dataclass
-class UDSEvent:
-    service: str                 # "0x10", "0x3E", ...
-    response_type: str           # "positive" | "negative"
-    code: Optional[int]          # NRC (긍정은 None)
-    raw: bytes                   # 수신 UDS PDU
-    timestamp: float             # 수신 시각
-    score: float = 0.0           # 부정응답 위험 점수
 
+# UDS 모니터 클래스
 
 class UDSMonitor:
-    """
-    - 디폴트 제거: YAML 설정 필수
-    - __init__() : 버스/스택 준비 + 설정 로드
-    - start()    : 0x10 → 응답 처리 → positive면 0x3E까지
-    """
+    def __init__(self, nrc_cfg_path: str = "config/nrc_weights.yaml"):
+        # NRC 점수 테이블 로드
+        self.NRC_CLASS = load_nrc_config(nrc_cfg_path)
 
-    def __init__(self,
-                 bus: Optional[can.Bus] = None,
-                 tx_id: int = TARGET_UDS_ID,
-                 rx_id: int = TARGET_UDS_ID + UDS_RESPONSE_OFFSET,
-                 nrc_cfg_path: str = "config/nrc_weights.yaml"):
+        # CAN & ISO-TP 초기화
+        self.bus = can.interface.Bus(channel=CAN_CHANNEL, bustype="socketcan")
+        addr = isotp.Address(
+            isotp.AddressingMode.Normal_11bits,
+            txid=TARGET_UDS_ID,
+            rxid=TARGET_UDS_ID + UDS_RESPONSE_OFFSET
+        )
+        self.stack = isotp.CanStack(bus=self.bus, address=addr, params=isotp_params)
+        
+        # FAIL 스코어 누적 (0~1 범위)
+        self._fail_score = 0.0
 
-        self.bus = bus or can.interface.Bus(bustype="socketcan", channel=CAN_CHANNEL)
-        self.addr = isotp.Address(isotp.AddressingMode.Normal_11bits, txid=tx_id, rxid=rx_id)
-        self.stack = isotp.CanStack(bus=self.bus, address=self.addr, params=_ISOTP_PARAMS)
 
-        # 설정 필수 로드
-        self._nrc_score, self._ctx_mul = load_nrc_config_strict(nrc_cfg_path)
+    # ISO-TP 송신
 
-    def start(self,
-              session_sub: int = 0x01,
-              tester_sub: int = 0x00,
-              t1: float = 1.0,
-              t2: float = 1.0) -> Dict[str, Optional[UDSEvent]]:
-
-        result: Dict[str, Optional[UDSEvent]] = {"0x10": None, "0x3E": None}
-
-        # Step 1: 0x10
-        self._send_uds(bytes([0x10, session_sub]))
-        evt10 = self._recv_one(expected_sid=0x10, timeout=t1)
-        result["0x10"] = evt10
-
-        # Step 2: 0x3E (only if positive 0x10)
-        if evt10 and evt10.response_type == "positive":
-            self._send_uds(bytes([0x3E, tester_sub]))
-            evt3e = self._recv_one(expected_sid=0x3E, timeout=t2)
-            result["0x3E"] = evt3e
-
-        return result
-
-    def _send_uds(self, uds_pdu: bytes) -> None:
-        self.stack.send(uds_pdu)
+    def send_request(self, data):
+        
+        self.stack.send(bytes(data))
         while self.stack.transmitting():
             self.stack.process()
-            time.sleep(0.002)
+            time.sleep(0.01)
 
-    def _recv_one(self, expected_sid: int, timeout: float) -> Optional[UDSEvent]:
-        """
-        기대 서비스(예: 0x10/0x3E)의 응답 1건 동기 수신.
-        - 0x7F: 설정된 NRC만 스코어링(미정의 NRC는 continue)
-        - positive: 그대로 반환
-        - timeout: None
-        """
-        deadline = time.time() + timeout
-        expected_tag = f"0x{expected_sid:02X}".lower()
+    # ISO-TP 수신
 
-        while time.time() < deadline:
+    def recv_response(self, timeout=1.0):
+     
+        start = time.time()
+        while time.time() - start < timeout:
             self.stack.process()
             if self.stack.available():
-                pdu = self.stack.recv()
-                ts = time.time()
-
-                evt = self._parse_uds_pdu(pdu, ts)
-                if not evt:
-                    continue
-                if evt.service.lower() != expected_tag:
-                    continue
-                if evt.response_type == "negative":
-                    if not self._score(evt):   # 미정의 NRC면 continue
-                        continue
-                return evt
-
-            time.sleep(self.stack.sleep_time())
-
+                resp = list(self.stack.recv())
+                 # ➜ 0x7F 0x78(Response Pending) → 아직 최종 응답이 아님, 타임아웃 안에서 재시도
+                if len(resp) >= 3 and resp[0] == 0x7F and resp[2] == 0x78:
+                    log_event("uds", TARGET_UDS_ID, "NRC_0x78_pending", "wait_more", "INFO")
+                    continue  # 최종 응답 올 때까지 루프 계속
+                return resp
+            time.sleep(0.01)
         return None
 
-    @staticmethod
-    def _parse_uds_pdu(pdu: bytes, ts: float) -> Optional[UDSEvent]:
-        if not pdu:
-            return None
-        # Negative: 0x7F <req_sid> <nrc>
-        if len(pdu) >= 3 and pdu[0] == 0x7F:
-            return UDSEvent(service=f"0x{pdu[1]:02X}", response_type="negative",
-                            code=pdu[2], raw=pdu, timestamp=ts)
-        # Positive: 0x40 + <req_sid>
-        if pdu[0] >= 0x40:
-            sid = pdu[0] - 0x40
-            return UDSEvent(service=f"0x{sid:02X}", response_type="positive",
-                            code=None, raw=pdu, timestamp=ts)
-        return None
 
-    def _score(self, evt: UDSEvent) -> bool:
-        """부정응답만 점수화. 설정 파일에 없는 NRC면 False(=무시)."""
-        if evt.response_type != "negative" or evt.code is None:
-            return True
-        base = self._nrc_score.get(evt.code)        # evt.code는 int
-        if base is None:
-            return False
-        ctx = self._ctx_mul.get(evt.service.lower(), 1.0)  # service는 '0x..' 소문자
-        evt.score = float(base) * float(ctx)
+    def start(self) -> float:
+        """
+        UDS 모니터링 시작
+        
+        :return: 최종 FAIL 스코어 (0.0 ~ 1.0+)
+        """
+        self._fail_score = 0.0  # 스코어 초기화
+        
+        try:
+            # 0x10 세션 진입
+            if not self._send_once_or_retry([0x10, 0x02], "session_entry", SCORE_NO_RESPONSE_0x10):
+                print("[INFO] UDS Monitor finished - Session entry failed")
+                return min(self._fail_score, 1.0)  # 1.0으로 제한
+
+            # 0x3E Tester Present
+            if not self._send_once_or_retry([0x3E, 0x00], "tester_present", SCORE_NO_RESPONSE_0x3E):
+                print("[INFO] UDS Monitor finished - Tester present failed")
+                return min(self._fail_score, 1.0)
+
+            # 0x19 DTC 읽기
+            self.send_request([0x19, 0x02])
+            total_dtc = self.collect_all_dtc()
+            
+            # DTC 스코어 계산 (0 ~ 1.0)
+            dtc_score = min(total_dtc / MAX_DTC_COUNT, 1.0)
+            self._fail_score += dtc_score
+            
+            log_event("uds", TARGET_UDS_ID, "DTC_count", total_dtc, "OK" if total_dtc == 0 else "FAIL")
+            log_event("uds", TARGET_UDS_ID, "DTC_score", dtc_score, "OK" if dtc_score < 0.5 else "FAIL")
+
+        except Exception as e:
+            log_event("uds", TARGET_UDS_ID, "exception", str(e), "FAIL")
+            self._fail_score = 1.0  # 예외 발생 시 최대 스코어
+        
+        # 최종 스코어는 1.0을 초과할 수 있음 (여러 FAIL이 누적될 경우)
+        print(f"[INFO] UDS Monitor finished - Total FAIL score: {self._fail_score:.3f}")
+        return self._fail_score
+
+    # 1회 전송 + 1회 재시도
+
+    def _send_once_or_retry(self, data, step_name, no_response_score):
+        """
+        요청 보내고 응답 확인, 없으면 한 번만 재시도
+        
+        :param data: 전송할 UDS 요청 데이터
+        :param step_name: 단계 이름 (로깅용)
+        :param no_response_score: 응답 없을 때 부여할 스코어 (0~1)
+        :return: 성공 여부
+        """
+        # 1차 요청
+        self.send_request(data)
+        resp = self.recv_response(timeout=1.0)
+
+        if not resp:
+            # 응답이 없으면 한 번만 재시도
+            self.send_request(data)
+            resp = self.recv_response(timeout=1.0)
+
+            if not resp:
+                self._fail_score += no_response_score
+                log_event("uds", TARGET_UDS_ID, f"{step_name}_no_response", no_response_score, "FAIL")
+                return False
+
+        # NRC 응답
+        if resp[0] == 0x7F:
+            nrc = resp[2]
+            if nrc in self.NRC_CLASS:
+                score = self.NRC_CLASS[nrc]
+                self._fail_score += score
+                log_event("uds", TARGET_UDS_ID, f"NRC_{hex(nrc)}", score, "FAIL")
+                return False
+            else:
+                # 알 수 없는 NRC는 정상으로 처리
+                log_event("uds", TARGET_UDS_ID, f"NRC_unknown_{hex(nrc)}", nrc, "WARN")
+                return True
+
+        # 정상 응답
+        log_event("uds", TARGET_UDS_ID, step_name, "response_ok", "OK")
         return True
+
+ 
+
+    #0x59 0x02 DTC 개수 계산
+    def collect_all_dtc(self):
+        
+        accumulated_data = bytearray()
+        start_time = time.time()
+
+        while time.time() - start_time < 2.0:
+            resp = self.recv_response(timeout=0.5)
+            if not resp:
+                break
+
+            # 정상 DTC 응답
+            if len(resp) >= 4 and resp[0] == 0x59 and resp[1] == 0x02:
+                # status mask(resp[2]) 건너뛰고 resp[3:]부터 누적
+                accumulated_data.extend(resp[3:])
+
+            # NRC 응답
+            elif resp[0] == 0x7F:
+                nrc = resp[2]
+                if nrc in self.NRC_CLASS:
+                    score = self.NRC_CLASS[nrc]
+                    self._fail_score += score
+                    log_event("uds", TARGET_UDS_ID, f"DTC_NRC_{hex(nrc)}", score, "FAIL")
+                else:
+                    log_event("uds", TARGET_UDS_ID, "DTC_NRC_Unknown", nrc, "WARN")
+                continue
+
+        total_dtc = len(accumulated_data) // 4  # 3바이트 코드 + 1바이트 상태
+        return total_dtc
+    
+    
+    def get_fail_score(self) -> float:
+        """
+        현재까지 누적된 FAIL 스코어 반환
+        0~1 범위
+        """
+        return self._fail_score

--- a/src/monitor/uds_monitor.py
+++ b/src/monitor/uds_monitor.py
@@ -1,200 +1,194 @@
 from dataclasses import dataclass
-from typing import List, Tuple, Dict, Optional, Callable
-import time
+from typing import Optional, Dict, Tuple
+import time, os
+import can
+import isotp
+import yaml
+
+CAN_CHANNEL         = "can0"
+TARGET_UDS_ID       = 0x366
+UDS_RESPONSE_OFFSET = 0x6A                 # 응답 ID = TARGET_UDS_ID + 0x6A
+PADDING_BYTE        = 0xAA                 # ISO-TP TX 패딩 바이트
+
+_ISOTP_PARAMS = {
+    "stmin": 0,
+    "blocksize": 8,
+    "wftmax": 0,
+    "tx_data_length": 8,
+    "tx_padding": PADDING_BYTE,
+    "rx_flowcontrol_timeout": 1000,
+    "rx_consecutive_frame_timeout": 1000,
+}
+
+def load_nrc_config_strict(path: str) -> Tuple[Dict[int, float], Dict[str, float]]:
+    """
+    엄격 모드:
+      - 파일/필드/형식이 틀리면 즉시 예외
+      - nrc_scores: 키는 반드시 '0x..' 16진 문자열 → int로 변환
+      - context_multipliers: 키는 반드시 '0x..' 소문자 16진 문자열
+    """
+    if not path or not os.path.exists(path):
+        raise FileNotFoundError(f"UDSMonitor config not found: {path}")
+
+    with open(path, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+
+    if not isinstance(data, dict):
+        raise ValueError("Config YAML root must be a mapping")
+
+    if "nrc_scores" not in data or "context_multipliers" not in data:
+        raise KeyError("Config must contain both 'nrc_scores' and 'context_multipliers'")
+
+    raw_scores = data["nrc_scores"]
+    raw_ctx    = data["context_multipliers"]
+
+    if not isinstance(raw_scores, dict) or not isinstance(raw_ctx, dict):
+        raise ValueError("'nrc_scores' and 'context_multipliers' must be mappings")
+
+    # nrc_scores: '0x..' 문자열 → int 키
+    nrc_scores: Dict[int, float] = {}
+    for k, v in raw_scores.items():
+        if not isinstance(k, str) or not k.strip().lower().startswith("0x"):
+            raise ValueError(f"NRC key must be hex string like '0x10', got {k!r}")
+        try:
+            ki = int(k.strip().lower(), 16)
+            vf = float(v)
+        except Exception as e:
+            raise ValueError(f"Invalid nrc_scores entry {k!r}:{v!r} → {e}")
+        nrc_scores[ki] = vf
+
+    # context_multipliers: '0x..' 소문자 16진 문자열
+    ctx_mul: Dict[str, float] = {}
+    for k, v in raw_ctx.items():
+        if not isinstance(k, str):
+            raise ValueError(f"Context key must be string like '0x10', got {type(k)}")
+        ks = k.strip().lower()
+        if not ks.startswith("0x"):
+            raise ValueError(f"Context key must start with '0x': {k!r}")
+        try:
+            int(ks, 16)  # 유효성 확인
+            vf = float(v)
+        except Exception as e:
+            raise ValueError(f"Invalid context_multipliers entry {k!r}:{v!r} → {e}")
+        ctx_mul[ks] = vf
+
+    if not nrc_scores:
+        raise ValueError("'nrc_scores' must not be empty")
+    if not ctx_mul:
+        raise ValueError("'context_multipliers' must not be empty")
+
+    return nrc_scores, ctx_mul
+
 
 @dataclass
 class UDSEvent:
-    service: str               
-    response_type: str           
-    code: Optional[int]
-    raw: bytes
-    timestamp: float
-
-class ISOTPAssembler:
-    def __init__(self):
-        self.buffer = bytearray()
-        self.expected_len = 0
-        self.next_sn = 1
-        self.in_progress = False
-
-    def feed(self, data: bytes) -> Optional[bytes]:
-        if not data:
-            return None
-
-        pci_type = (data[0] & 0xF0) >> 4
-        pci_low  =  data[0] & 0x0F
-
-        # SF: Single Frame (<=7 data bytes)
-        if pci_type == 0x0:
-            length = pci_low
-            return data[1:1 + length]
-
-        # FF: First Frame
-        elif pci_type == 0x1:
-            self.expected_len = ((pci_low << 8) | data[1])
-            self.buffer = bytearray(data[2:])
-            self.in_progress = True
-            self.next_sn = 1
-            return None  # wait for CFs
-
-        # CF: Consecutive Frame
-        elif pci_type == 0x2 and self.in_progress:
-            sn = pci_low
-            # sequence check
-            if sn != (self.next_sn & 0x0F):
-                self.reset()
-                return None
-            self.next_sn += 1
-            self.buffer.extend(data[1:])
-            if len(self.buffer) >= self.expected_len:
-                pdu = bytes(self.buffer[:self.expected_len])
-                self.reset()
-                return pdu
-            return None
-
-        # FC: Flow Control (0x3) → ignore (receiver side)
-        else:
-            return None
-
-    def reset(self):
-        self.buffer = bytearray()
-        self.expected_len = 0
-        self.next_sn = 1
-        self.in_progress = False
+    service: str                 # "0x10", "0x3E", ...
+    response_type: str           # "positive" | "negative"
+    code: Optional[int]          # NRC (긍정은 None)
+    raw: bytes                   # 수신 UDS PDU
+    timestamp: float             # 수신 시각
+    score: float = 0.0           # 부정응답 위험 점수
 
 
 class UDSMonitor:
     """
-    - send_0x10 / send_0x3e: 단일프레임 송신 + 응답 대기/분류
-    - probe_session_then_tester_present: 0x10 긍정이면 0x3E 연속 수행
+    - 디폴트 제거: YAML 설정 필수
+    - __init__() : 버스/스택 준비 + 설정 로드
+    - start()    : 0x10 → 응답 처리 → positive면 0x3E까지
     """
-    def __init__(
-        self,
-        tx_id: int = 0x7E0,
-        rx_id: int = 0x7E8,
-        sender: Optional[Callable[[int, bytes], None]] = None,
-        collector: Optional[Callable[[float], List[Tuple[int, bytes, float]]]] = None,
-    ):
-        self.tx_id = tx_id
-        self.rx_id = rx_id
-        self.sender = sender          
-        self.collector = collector    
-        self.assembler = ISOTPAssembler()
 
-    # -------------------------
-    # Parse UDS response (positive/negative만 생성)
-    # -------------------------
-    @staticmethod
-    def parse_uds_pdu(pdu: bytes) -> Optional["UDSEvent"]:
-        # Negative Response (0x7F <req_service> <NRC>)
-        if len(pdu) >= 3 and pdu[0] == 0x7F:
-            req_srv, nrc = pdu[1], pdu[2]
-            return UDSEvent(f"0x{req_srv:02X}", "negative", nrc, pdu, time.time())
+    def __init__(self,
+                 bus: Optional[can.Bus] = None,
+                 tx_id: int = TARGET_UDS_ID,
+                 rx_id: int = TARGET_UDS_ID + UDS_RESPONSE_OFFSET,
+                 nrc_cfg_path: str = "config/nrc_weights.yaml"):
 
-        # Positive Response (0x40 + <req_service>)
-        if len(pdu) >= 1 and pdu[0] >= 0x40:
-            service = pdu[0] - 0x40
-            return UDSEvent(f"0x{service:02X}", "positive", None, pdu, time.time())
+        self.bus = bus or can.interface.Bus(bustype="socketcan", channel=CAN_CHANNEL)
+        self.addr = isotp.Address(isotp.AddressingMode.Normal_11bits, txid=tx_id, rxid=rx_id)
+        self.stack = isotp.CanStack(bus=self.bus, address=self.addr, params=_ISOTP_PARAMS)
 
-        # 그 외는 이벤트 생성 안 함
-        return None
+        # 설정 필수 로드
+        self._nrc_score, self._ctx_mul = load_nrc_config_strict(nrc_cfg_path)
 
-    @staticmethod
-    def _build_sf_from_uds_pdu(uds_pdu: bytes) -> bytes:
-        """
-        UDS PDU (<=7 bytes)를 ISO-TP Single Frame로 캡슐화해 8바이트 반환.
-        """
-        if len(uds_pdu) > 7:
-            raise ValueError("PDU too long for Single Frame")
-        pad_len = 7 - len(uds_pdu)
-        return bytes([len(uds_pdu)]) + uds_pdu + bytes(pad_len)
+    def start(self,
+              session_sub: int = 0x01,
+              tester_sub: int = 0x00,
+              t1: float = 1.0,
+              t2: float = 1.0) -> Dict[str, Optional[UDSEvent]]:
 
-    def _wait_one_uds_event(
-        self,
-        expected_service: int,
-        timeout: float = 1.0,
-        poll_interval: float = 0.02,
-    ) -> Optional[UDSEvent]:
-        """
-        collector를 폴링하여 응답 하나를 조립 완료될 때까지 기다리고 반환.
-        expected_service와 매칭되는 positive/negative만 리턴.
-        """
-        if not self.collector:
-            return None
-
-        t0 = time.time()
-        last_ts = t0
-        while time.time() - t0 < timeout:
-            frames = self.collector(last_ts)  
-            if frames:
-                last_ts = max(last_ts, max(ts for _, _, ts in frames))
-            for arbid, data, ts in frames:
-                if arbid != self.rx_id:
-                    continue
-                pdu = self.assembler.feed(data)
-                if pdu is None:
-                    continue
-                evt = self.parse_uds_pdu(pdu)
-                if evt is not None:
-                    evt.timestamp = ts
-                    # positive: 0x40+expected_service
-                    # negative: 0x7F,<expected_service>,<NRC>
-                    if evt.service.lower() == f"0x{expected_service:02x}":
-                        return evt
-            time.sleep(poll_interval)
-
-        return None  # timeout
-
-    # -------------------------
-    # Send 0x10 & wait response
-    # -------------------------
-    def send_0x10(self, subfunc: int = 0x01, timeout: float = 1.0) -> Optional[UDSEvent]:
-        if not self.sender:
-            raise RuntimeError("sender is not set")
-        uds_pdu = bytes([0x10, subfunc])
-        can_data = self._build_sf_from_uds_pdu(uds_pdu)
-        self.sender(self.tx_id, can_data)
-        return self._wait_one_uds_event(expected_service=0x10, timeout=timeout)
-
-    # -------------------------
-    # Send 0x3E & wait response
-    # -------------------------
-    def send_0x3e(self, subfunc: int = 0x00, timeout: float = 1.0) -> Optional[UDSEvent]:
-        if not self.sender:
-            raise RuntimeError("sender is not set")
-        uds_pdu = bytes([0x3E, subfunc])
-        can_data = self._build_sf_from_uds_pdu(uds_pdu)
-        self.sender(self.tx_id, can_data)
-        return self._wait_one_uds_event(expected_service=0x3E, timeout=timeout)
-
-    # -------------------------
-    # Sequence: 0x10 → (positive) 0x3E
-    # -------------------------
-    def probe_session_then_tester_present(
-        self,
-        session_sub: int = 0x01,
-        tester_sub: int = 0x00,
-        t1: float = 1.0,
-        t2: float = 1.0,
-    ) -> Dict[str, Optional[UDSEvent]]:
-        """
-        1) 0x10 세션 전환 요청 → 응답 분류
-        2) positive면 0x3E tester present → 응답 분류
-        """
         result: Dict[str, Optional[UDSEvent]] = {"0x10": None, "0x3E": None}
-        evt10 = self.send_0x10(session_sub, timeout=t1)
+
+        # Step 1: 0x10
+        self._send_uds(bytes([0x10, session_sub]))
+        evt10 = self._recv_one(expected_sid=0x10, timeout=t1)
         result["0x10"] = evt10
 
+        # Step 2: 0x3E (only if positive 0x10)
         if evt10 and evt10.response_type == "positive":
-            evt3e = self.send_0x3e(tester_sub, timeout=t2)
+            self._send_uds(bytes([0x3E, tester_sub]))
+            evt3e = self._recv_one(expected_sid=0x3E, timeout=t2)
             result["0x3E"] = evt3e
 
         return result
 
-    # -------------------------
-    # Simple print helper (optional)
-    # -------------------------
-    def interpret(self, events: List[UDSEvent]) -> None:
-        print("UDS Monitor Events:")
-        for e in events:
-            print(f"  [{e.timestamp:.3f}] {e.service:<6} {e.response_type:<9} {e.code or '-'} {e.raw.hex().upper()}")
+    def _send_uds(self, uds_pdu: bytes) -> None:
+        self.stack.send(uds_pdu)
+        while self.stack.transmitting():
+            self.stack.process()
+            time.sleep(0.002)
+
+    def _recv_one(self, expected_sid: int, timeout: float) -> Optional[UDSEvent]:
+        """
+        기대 서비스(예: 0x10/0x3E)의 응답 1건 동기 수신.
+        - 0x7F: 설정된 NRC만 스코어링(미정의 NRC는 continue)
+        - positive: 그대로 반환
+        - timeout: None
+        """
+        deadline = time.time() + timeout
+        expected_tag = f"0x{expected_sid:02X}".lower()
+
+        while time.time() < deadline:
+            self.stack.process()
+            if self.stack.available():
+                pdu = self.stack.recv()
+                ts = time.time()
+
+                evt = self._parse_uds_pdu(pdu, ts)
+                if not evt:
+                    continue
+                if evt.service.lower() != expected_tag:
+                    continue
+                if evt.response_type == "negative":
+                    if not self._score(evt):   # 미정의 NRC면 continue
+                        continue
+                return evt
+
+            time.sleep(self.stack.sleep_time())
+
+        return None
+
+    @staticmethod
+    def _parse_uds_pdu(pdu: bytes, ts: float) -> Optional[UDSEvent]:
+        if not pdu:
+            return None
+        # Negative: 0x7F <req_sid> <nrc>
+        if len(pdu) >= 3 and pdu[0] == 0x7F:
+            return UDSEvent(service=f"0x{pdu[1]:02X}", response_type="negative",
+                            code=pdu[2], raw=pdu, timestamp=ts)
+        # Positive: 0x40 + <req_sid>
+        if pdu[0] >= 0x40:
+            sid = pdu[0] - 0x40
+            return UDSEvent(service=f"0x{sid:02X}", response_type="positive",
+                            code=None, raw=pdu, timestamp=ts)
+        return None
+
+    def _score(self, evt: UDSEvent) -> bool:
+        """부정응답만 점수화. 설정 파일에 없는 NRC면 False(=무시)."""
+        if evt.response_type != "negative" or evt.code is None:
+            return True
+        base = self._nrc_score.get(evt.code)        # evt.code는 int
+        if base is None:
+            return False
+        ctx = self._ctx_mul.get(evt.service.lower(), 1.0)  # service는 '0x..' 소문자
+        evt.score = float(base) * float(ctx)
+        return True

--- a/src/seeds/dbc_parser.py
+++ b/src/seeds/dbc_parser.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Any, Union
+import cantools
+
+def _normalize_byte_order_from_cantools(byte_order: str) -> str:
+    
+    b = (byte_order or "").lower()
+    # None 방지, 소문자 통일
+
+    if b == "little_endian":
+        return "little_endian"
+    if b == "big_endian":
+        return "big_endian"
+    return "little_endian"
+
+def parse(path: Union[str, Path]) -> Dict[str, Any]:
+    """
+    입력: .dbc 텍스트 파일 경로
+    출력: 표준화된 dict 스키마
+      {
+        "messages": {
+          "<MessageName>": {
+            "name": str,
+            "frame_id": int,
+            "dlc": int,
+            "signals": {
+              "<SignalName>": {
+                "name": str,
+                "start_bit": int,
+                "length": int,
+                "byte_order": "little_endian"|"big_endian",
+                "is_signed": bool,
+                "scale": float,
+                "offset": float,
+                "minimum": float|null,
+                "maximum": float|null,
+                "unit": str|null,
+                "choices": {int: str}|null
+              }
+            }
+          }
+        }
+      }
+    """
+    p = Path(path)     #문자열 경로를 Path 객체로 변환
+
+    if not p.exists():
+        raise FileNotFoundError(f"파일을 찾을 수 없습니다: {p}")
+    if p.suffix.lower() != ".dbc":
+        raise ValueError("이 파서는 .dbc 파일만 지원합니다.")
+
+    text = p.read_text(encoding="utf-8-sig")
+
+    db = cantools.database.load_string(text)
+
+    out: Dict[str, Any] = {"messages": {}}
+
+    # cantools의 모델을 표준 스키마로 매핑
+    for msg in db.messages:
+        m_name = msg.name
+        frame_id = int(msg.frame_id)   
+        dlc = int(msg.length)          
+
+        signals_out: Dict[str, Any] = {}
+        for sig in msg.signals:
+            start_bit = int(sig.start)                  
+            length = int(sig.length)                    
+            byte_order = _normalize_byte_order_from_cantools(sig.byte_order)
+            is_signed = bool(sig.is_signed)
+            scale = float(sig.scale if sig.scale is not None else 1.0)
+            offset = float(sig.offset if sig.offset is not None else 0.0)
+            minimum = None if sig.minimum is None else float(sig.minimum)
+            maximum = None if sig.maximum is None else float(sig.maximum)
+            unit = None if not sig.unit else str(sig.unit)
+
+            choices = None
+            if sig.choices:
+                choices = {int(k): str(v) for k, v in sig.choices.items()}
+
+            # 표준 신호 스키마로 한 신호를 완성해서, 신호 이름을 키로 signals_out에 저장
+            signals_out[sig.name] = {
+                "name": sig.name,
+                "start_bit": start_bit,
+                "length": length,
+                "byte_order": byte_order,             
+                "is_signed": is_signed,
+                "scale": scale,
+                "offset": offset,
+                "minimum": minimum,
+                "maximum": maximum,
+                "unit": unit,
+                "choices": choices,
+            }
+
+        out["messages"][m_name] = {
+            "name": m_name,
+            "frame_id": frame_id,
+            "dlc": dlc,
+            "signals": signals_out,
+        }
+
+    return out

--- a/src/seeds/seed_manager.py
+++ b/src/seeds/seed_manager.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from .dbc_parser import parse as parse_dbc
+
+@dataclass
+class SignalMeta:
+    start_bit: int
+    length: int
+    byte_order: str                 
+    is_signed: bool
+    scale: float
+    offset: float
+    minimum: Optional[float]
+    maximum: Optional[float]
+    unit: Optional[str]
+    choices: Optional[Dict[int, str]]  # {값: 라벨}
+
+@dataclass
+class Seed:
+    message_name: str
+    frame_id: int
+    signal_name: str
+    dlc: int
+    meta: SignalMeta
+
+class SeedManager:
+    """
+    필수 기능:
+      - add_seed(seed): 1건 저장
+      - get_all(): 전건 조회
+    meta는 JSON 문자열로 저장
+    """
+    def __init__(self, db_path: str | Path) -> None:
+        self.db_path = str(db_path)
+        self.conn = sqlite3.connect(self.db_path)
+        self.conn.row_factory = sqlite3.Row
+        self._ensure_schema()
+
+    def _ensure_schema(self) -> None:
+        self.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS seeds (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                message_name TEXT NOT NULL,
+                frame_id     INTEGER NOT NULL,
+                signal_name  TEXT NOT NULL,
+                dlc          INTEGER NOT NULL,
+                meta_json    TEXT NOT NULL,
+                created_at   TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        self.conn.commit()
+
+    def add_seed(self, seed: Seed) -> int:
+        cur = self.conn.execute(
+            """
+            INSERT INTO seeds (message_name, frame_id, signal_name, dlc, meta_json)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                seed.message_name,
+                seed.frame_id,
+                seed.signal_name,
+                seed.dlc,
+                json.dumps(asdict(seed.meta), ensure_ascii=False),
+            ),
+        )
+        self.conn.commit()
+        return int(cur.lastrowid)
+
+    def get_all(self) -> List[Seed]:
+        rows = self.conn.execute(
+            "SELECT message_name, frame_id, signal_name, dlc, meta_json FROM seeds ORDER BY id ASC"
+        ).fetchall()
+
+        out: List[Seed] = []
+        for r in rows:
+            meta = SignalMeta(**json.loads(r["meta_json"]))
+            out.append(
+                Seed(
+                    message_name=r["message_name"],
+                    frame_id=int(r["frame_id"]),
+                    signal_name=r["signal_name"],
+                    dlc=int(r["dlc"]),
+                    meta=meta,
+                )
+            )
+        return out
+
+    def close(self) -> None:
+        try:
+            self.conn.close()
+        except Exception:
+            pass
+
+def from_dbc(parsed: Dict[str, Any]) -> List[Seed]:
+    # dbc_parser.parse() 결과(dict) → Seed 리스트
+
+    seeds: List[Seed] = []
+    for mname, m in (parsed.get("messages") or {}).items():
+        frame_id = int(m["frame_id"])
+        dlc = int(m.get("dlc", 8))
+        for sname, s in (m.get("signals") or {}).items():
+            meta = SignalMeta(
+                start_bit=int(s["start_bit"]),
+                length=int(s["length"]),
+                byte_order=str(s["byte_order"]),     
+                is_signed=bool(s["is_signed"]),
+                scale=float(s["scale"]),
+                offset=float(s["offset"]),
+                minimum=s.get("minimum"),
+                maximum=s.get("maximum"),
+                unit=s.get("unit"),
+                choices=s.get("choices"),
+            )
+            seeds.append(
+                Seed(
+                    message_name=mname,
+                    frame_id=frame_id,
+                    signal_name=sname,
+                    dlc=dlc,
+                    meta=meta,
+                )
+            )
+    return seeds
+
+if __name__ == "__main__":
+    """
+    사용법:
+        python -m src.seeds.seed_manager <path_to_dbc> [--db .seeds.db]
+    """
+    import argparse
+
+    ap = argparse.ArgumentParser()
+    ap.add_argument("input", help="Path to .dbc (required)")
+    ap.add_argument("--db", default=".seeds.db", help="SQLite file (default: .seeds.db)")
+    args = ap.parse_args()
+
+    in_path = Path(args.input)
+    if not in_path.exists():
+        print(f"[ERROR] DBC 파일을 찾을 수 없습니다: {in_path}", file=sys.stderr)
+        sys.exit(2)
+    if in_path.suffix.lower() != ".dbc":
+        print(f"[ERROR] 이 단계는 .dbc만 지원합니다: {in_path}", file=sys.stderr)
+        sys.exit(2)
+
+    # 1) DBC 파싱(정규화 dict)
+    parsed = parse_dbc(in_path)
+
+    # 2) 파싱 결과 → Seed 리스트
+    seeds = from_dbc(parsed)
+    if not seeds:
+        print("[WARN] 변환된 Seed가 없습니다. DBC 내용을 확인하세요.", file=sys.stderr)
+
+    # 3) DB 저장 → 조회
+    mgr = SeedManager(args.db)
+    try:
+        for s in seeds:
+            mgr.add_seed(s)
+
+        loaded = mgr.get_all()
+        print(f"[INFO] saved={len(seeds)}, loaded={len(loaded)}")
+        for s in loaded:
+            print(
+                f"- {s.message_name} (0x{s.frame_id:X}, dlc={s.dlc}) :: "
+                f"{s.signal_name} [{s.meta.start_bit}:{s.meta.length} {s.meta.byte_order}]"
+            )
+    finally:
+        mgr.close()


### PR DESCRIPTION
## 📌 PR 개요
- UDS 모니터 로직 개선을 위해 NRC 0x78(Response Pending) 처리 기능을 추가했습니다.
- ECU가 작업 중일 때 올 수 있는 0x7F 0x78 응답을 정상 플로우에 포함시켜, 발생할 수 있는 문제를 방지합니다.

## 🔍 주요 변경 사항
- 0x78(Response Pending) 처리 로직 추가
- recv_response() 내에서 0x7F 0x78 수신 시 타임아웃 범위 내에서 재대기하도록 변경
- 기존에는 Response Pending을 FAIL처럼 오해할 가능성이 있었음

## ✅ 체크리스트
- [ ] 실차 환경에서 0x78 수신 시 재대기 정상 동작 확인
- [ ] 기존 FAIL 스코어 로직과 충돌 없음 확인

## ⚠️ 기타 참고 사항
- 현재는 Response Pending 대기만 반영했고, 필요 시 추후에 최대 Pending 반복 횟수 제한도 추가할 수 있습니다.