### PR TITLE
Feature/dbc-monitor_refactoring: TARGET_ID 수정 및 fail_score 로직 변경

### DIFF
--- a/src/monitor/dbc_monitor.py
+++ b/src/monitor/dbc_monitor.py
@@ -263,7 +263,7 @@ class DBCMonitor:
 
     def _update_fail_score(self):
         if self._total_checks > 0:
-            self._fail_score = min(self._fail_count / self._total_checks, 1.0)
+            self._fail_score = 1.0 if self._fail_count > 0 else 0.0
 
     def _emit(self, metric: str, sig: str, value: Any, status: str):
         ev = {

--- a/src/monitor/dbc_monitor.py
+++ b/src/monitor/dbc_monitor.py
@@ -209,7 +209,6 @@ class DBCMonitor:
 
         # range 검사
         mn, mx = rule.get("min"), rule.get("max")
-        range_ok = True
 
         if mn is not None:
             self._total_checks += 1
@@ -234,7 +233,6 @@ class DBCMonitor:
         mode = rule.get("monotonic")
         if mode:
             prev = self._prev_values.get(sig)
-            mono_ok = True
             
             if prev is not None:
                 self._total_checks += 1

--- a/src/monitor/dbc_monitor.py
+++ b/src/monitor/dbc_monitor.py
@@ -11,7 +11,7 @@ from seeds.seed_manager import SeedManager
 
 CAN_CHANNEL = "can0"
 DBC_PATH    = "db/your.ecu.dbc"   
-TARGET_ID   = 0x366               
+TARGET_ID   = 0x6A6               
 Number = Union[int, float]
 
 class DBCMonitor:
@@ -95,33 +95,47 @@ class DBCMonitor:
         print(f"         DBC={self.dbc_path}, signals={list(self.rules.keys()) or '—'}")
 
         while True:
-            msg = self.bus.recv(timeout=1)
-            if not msg or msg.arbitration_id != self.target_id:
-                continue
-
-            # 디코드 실패는 즉시 예외로 올림
             try:
-                decoded = self.msg_def.decode(bytes(msg.data), decode_choices=False, scaling=True)
-            except Exception as e:
-                self._emit("decode_error", "_frame", str(e), "FAIL")
-                raise RuntimeError(f"DBC decode 실패: {e}") from e
+                msg = self.bus.recv(timeout=1)
+                if not msg or msg.arbitration_id != self.target_id:
+                    continue
+
+            # 디코드 실패
+                try:
+                    decoded = self.msg_def.decode(bytes(msg.data), decode_choices=False, scaling=True)
+                
+                except Exception as e:
+                    self._emit("decode_error", "_frame", str(e), "FAIL")
+                    continue
 
             # 신호별 검사
-            for sig, rule in self.rules.items():
-                if sig not in decoded:
-                    self._emit("missing_signal", sig, None, "FAIL")
-                    raise RuntimeError(f"신호 누락: {sig} - DBC에 정의된 신호가 디코딩 결과에 없습니다.")
+                for sig, rule in self.rules.items():
+                    try: 
+                        if sig not in decoded:
+                            self._emit("missing_signal", sig, None, "FAIL")
+                            raise RuntimeError(f"신호 누락: {sig} - DBC에 정의된 신호가 디코딩 결과에 없습니다.")
 
-                raw = decoded[sig]
+                        raw = decoded[sig]
 
-                # 타입 정규화 실패는 즉시 예외
-                try:
-                    val = self._normalize_value(raw, rule)
-                except Exception as e:
-                    self._emit("type_cast", sig, raw, "FAIL")
-                    raise ValueError(f"type cast 실패: signal={sig}, value={raw!r}") from e
+                # 타입 정규화 
+                        try:
+                            val = self._normalize_value(raw, rule)
+                        except Exception as e:
+                            self._emit("type_cast", sig, raw, "FAIL")
+                            raise ValueError(f"type cast 실패: signal={sig}, value={raw!r}") from e
 
-                self._check_rules(sig, val, rule)
+                        try:
+                            self._check_rules(sig, val, rule)
+                        except Exception as e:
+                            raise RuntimeError(f"rule 위반: signal={sig}, value={val}, err={e}"
+                        ) from e
+                    
+                    except Exception as sig_err:
+                        continue
+
+            except KeyboardInterrupt:
+                print("[ INFO ] KeyboardInterrupt: stopping monitor")
+                break
 
     # ─────────────────────────────────────────────────────────────────────
     def _normalize_value(self, raw: Any, rule: Dict[str, Any]) -> Number: # 규칙에 맞춰 값을 bool/int/float로 정규화
@@ -145,41 +159,48 @@ class DBCMonitor:
         enum_vals = rule.get("enum")
         if enum_vals is not None:
             if rule.get("kind") == "float":
-                ok = any(float(val) == float(a) for a in enum_vals)
+                enum_ok = any(float(val) == float(a) for a in enum_vals)
             else:
-                ok = val in set(int(a) for a in enum_vals)
+                enum_ok = val in set(int(a) for a in enum_vals)
 
-            self._emit("enum", sig, val, "OK" if ok else "FAIL")
-            if not ok:
+            self._emit("enum", sig, val, "OK" if enum_ok else "FAIL")
+
+            if not enum_ok:
                 raise RuntimeError(f"enum 위반: {sig} value={val}, 허용={enum_vals}")
 
         # range 검사
         mn, mx = rule.get("min"), rule.get("max")
+        range_ok = True
 
         if mn is not None and float(val) < float(mn):
-            self._emit("range", sig, val, "FAIL")
-            raise RuntimeError(f"range 하한 위반: {sig} value={val}, min={mn}")
-
+            range_ok = False
         if mx is not None and float(val) > float(mx):
-            self._emit("range", sig, val, "FAIL")
-            raise RuntimeError(f"range 상한 위반: {sig} value={val}, max={mx}")
+            range_ok = False
 
-        self._emit("range", sig, val, "OK")
+        self._emit("range", sig, val, "OK" if range_ok else "FAIL")
+
+        if not range_ok:
+            raise RuntimeError(f"range 위반: {sig} value={val}, min={mn}, max={mx}")
 
         # 단조성 검사
         mode = rule.get("monotonic")
         if mode:
             prev = self._prev_values.get(sig)
+            mono_ok = True
+            
             if prev is not None:
                 pv = float(prev)
                 cv = float(val)
+
                 if mode == "nondecreasing" and cv < pv:
-                    self._emit("monotonic", sig, {"prev": prev, "cur": val, "mode": mode}, "FAIL")
-                    raise RuntimeError(f"단조성 위반: {sig} {prev} → {val} (nondecreasing)")
+                    mono_ok = False
                 if mode == "nonincreasing" and cv > pv:
-                    self._emit("monotonic", sig, {"prev": prev, "cur": val, "mode": mode}, "FAIL")
-                    raise RuntimeError(f"단조성 위반: {sig} {prev} → {val} (nonincreasing)")
-            self._emit("monotonic", sig, {"prev": prev, "cur": val, "mode": mode}, "OK") # prev가 없거나 위반이 없으면 OK로 기록
+                    mono_ok = False
+
+            self._emit("monotonic", sig, {"prev": prev, "cur": val, "mode": mode}, "OK" if mono_ok else "FAIL")
+
+            if not mono_ok:
+                raise RuntimeError(f"단조성 위반: {sig} {prev} → {val} ({mode})")
 
         self._prev_values[sig] = val # 정상 통과 시 이전값 갱신
 


### PR DESCRIPTION
## 📌 PR 개요
- DBC monitor의 TARGET_ID를 0x366에서 0x6A6으로 변경하였습니다.
- fail_score 계산 방식을 바이너리 방식으로 변경하였습니다.

## 🔍 주요 변경 사항
- TARGET_ID = 0x6A6으로 수정
- fail_score 계산 로직 바이너리 방식으로 변경
   - 기존: fail_count / total_checks 비율 기반
   - 변경: 한 번이라도 FAIL 발생 시 fail_score = 1.0

## ✅ 체크리스트
- [ ] 0x6A6 DBC 기준 decode 및 rule 적용 확인
- [ ] FAIL 1회 발생 시 fail_score 1.0으로 상승하는 로직 검증

## ⚠️ 기타 참고 사항
- fail_score가 바이너리로 동작 -> 단일 위반에도 전체 테스트 FAIL 처리