### PR TITLE
Feature/UDS_monitor_refactoring: TARGET_ID 수정 및 0x78 Response Pending 대기 로직 추가

### DIFF
--- a/src/monitor/uds_monitor.py
+++ b/src/monitor/uds_monitor.py
@@ -10,7 +10,7 @@ from logger.base_logger import log_event
 # 모니터링 설정값
 
 CAN_CHANNEL = "can0"
-TARGET_UDS_ID = 0x366
+TARGET_UDS_ID = 0x6A6
 UDS_RESPONSE_OFFSET = 0x6A
 PADDING_BYTE = 0xAA
 
@@ -92,7 +92,12 @@ class UDSMonitor:
         while time.time() - start < timeout:
             self.stack.process()
             if self.stack.available():
-                return list(self.stack.recv())
+                resp = list(self.stack.recv())
+                 # ➜ 0x7F 0x78(Response Pending) → 아직 최종 응답이 아님, 타임아웃 안에서 재시도
+                if len(resp) >= 3 and resp[0] == 0x7F and resp[2] == 0x78:
+                    log_event("uds", TARGET_UDS_ID, "NRC_0x78_pending", "wait_more", "INFO")
+                    continue  # 최종 응답 올 때까지 루프 계속
+                return resp
             time.sleep(0.01)
         return None
 


### PR DESCRIPTION
## 📌 PR 개요
- UDS 모니터 로직 개선을 위해 NRC 0x78(Response Pending) 처리 기능을 추가했습니다.
- ECU가 작업 중일 때 올 수 있는 0x7F 0x78 응답을 정상 플로우에 포함시켜, 발생할 수 있는 문제를 방지합니다.
- UDS monitor의 TARGET_ID를 0x366에서 0x6A6으로 변경하였습니다.

## 🔍 주요 변경 사항
- 0x78(Response Pending) 처리 로직 추가
- recv_response() 내에서 0x7F 0x78 수신 시 타임아웃 범위 내에서 재대기하도록 변경
- 기존에는 Response Pending을 FAIL처럼 오해할 가능성이 있었음
- TARGET_ID = 0x6A6으로 수정

## ✅ 체크리스트
- [ ] 실차 환경에서 0x78 수신 시 재대기 정상 동작 확인
- [ ] 기존 FAIL 스코어 로직과 충돌 없음 확인

## ⚠️ 기타 참고 사항
- 현재는 Response Pending 대기만 반영했고, 필요 시 추후에 최대 Pending 반복 횟수 제한도 추가할 수 있습니다.