### PR TITLE
Refactor/cli-pipeline-test-version: MonitorManager 상태 체계 추가 및 전체 파이프라인 연동 리팩토링

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -1,7 +1,8 @@
 # src/cli.py
+
 import json
 import click
-from pipeline import AutoFuzzPipeline
+from .pipeline import AutoFuzzPipeline
 
 
 @click.group()
@@ -31,33 +32,39 @@ def list(db):
     click.echo(f"[+] {len(seeds)} seeds loaded:")
     click.echo("-" * 60)
     for s in seeds:
-        click.echo(f"[{s.id:03}] {s.signal_name:<25} | msg_id={hex(s.message_id)} | priority={s.priority}")
+        click.echo(
+            f"[{s.id:03}] {s.signal_name:<25} "
+            f"| msg_id={hex(s.message_id)} | priority={s.priority}"
+        )
     click.echo("-" * 60)
 
 
-# Monitor 결과 출력
+# 모니터 결과 UI
 def print_monitor_results(results: dict):
     click.echo(click.style("\n=== AutoFuzz Monitor Results ===\n", fg="cyan", bold=True))
 
     for name, v in results.items():
         monitor = name.upper()
+        score_val = v.get("score", 0.0)
+        status = v.get("status", "unknown")
 
-        # 상태 색상 + 아이콘
-        if v["completed"]:
-            status_icon = click.style("✓", fg="green")
-            status_text = click.style("completed", fg="green")
+        # 상태 텍스트 색상 처리
+        if status == "ok":
+            status_text = click.style("OK", fg="green")
+        elif status == "timeout":
+            status_text = click.style("TIMEOUT", fg="yellow")
+        elif status == "crashed":
+            status_text = click.style("CRASHED", fg="red")
+        elif status == "skipped":
+            status_text = click.style("SKIPPED", fg="blue")
         else:
-            status_icon = click.style("✗", fg="red")
-            status_text = click.style("timeout", fg="red")
+            status_text = click.style("UNKNOWN", fg="white")
 
         # 점수 색상
-        score = click.style(f"{v['score']:.3f}", fg="cyan")
+        score_text = click.style(f"{score_val:.3f}", fg="cyan")
 
-        click.echo(
-            f"{status_icon} {click.style(monitor, bold=True):<10} "
-            f"Score: {score}  ({status_text})"
-        )
-        
+        click.echo(f"{monitor:<10} | Score: {score_text} | Status: {status_text}")
+
     click.echo()
 
 
@@ -79,7 +86,7 @@ def run(db, channel, can, can_id, save_json):
         click.echo("[!] Invalid CAN ID format.")
         return
 
-    # 인터페이스 준비
+    # CAN 인터페이스 준비
     can_iface = None
     if can:
         from interface.can_interface import CANInterface

--- a/src/monitor/monitor_manager.py
+++ b/src/monitor/monitor_manager.py
@@ -1,11 +1,8 @@
-# src/monitor/monitor_manager.py
-
 import threading
-import time
 from typing import Dict, Optional
-from monitor.timing_monitor import TimingMonitor
-from monitor.uds_monitor import UDSMonitor
-from monitor.dbc_monitor import DBCMonitor
+from .timing_monitor import TimingMonitor
+from .uds_monitor import UDSMonitor
+from .dbc_monitor import DBCMonitor
 
 
 class MonitorManager:
@@ -20,23 +17,34 @@ class MonitorManager:
         self.uds_monitor = uds_monitor
         self.dbc_monitor = dbc_monitor
 
+        # 각 모니터 스레드
         self.threads: Dict[str, threading.Thread] = {}
 
+        # 모니터 상태 및 점수
+        # status: "pending" | "running" | "ok" | "timeout" | "crashed" | "skipped"
         self.scores: Dict[str, float] = {
             "timing": 0.0,
             "uds": 0.0,
             "dbc": 0.0
         }
-        self.scores_lock = threading.Lock()
-
+        self.status: Dict[str, str] = {
+            "timing": "pending",
+            "uds": "pending",
+            "dbc": "pending"
+        }
         self.completed: Dict[str, bool] = {
             "timing": False,
             "uds": False,
             "dbc": False
         }
 
+        # scores + status + completed를 함께 보호하는 락
+        self.state_lock = threading.Lock()
+
         self.running = False
 
+
+    # 모니터 시작
     def start_monitors(
         self,
         timing_timeout: Optional[float] = 5.0,
@@ -44,6 +52,7 @@ class MonitorManager:
     ):
         """
         각 모니터를 별도 스레드로 시작
+        여러 번 호출될 수 있으므로, 호출 시 상태 초기화 + thread dict 초기화
         """
         if self.running:
             print("[WARN] Monitors are already running")
@@ -52,13 +61,20 @@ class MonitorManager:
         self.running = True
         print("[INFO] Starting monitors...")
 
-        # 초기화
-        with self.scores_lock:
+        # threads 재사용 방지: 매번 초기화
+        self.threads = {}
+
+        # 상태 초기화
+        with self.state_lock:
             self.scores = {"timing": 0.0, "uds": 0.0, "dbc": 0.0}
             self.completed = {"timing": False, "uds": False, "dbc": False}
+            self.status = {"timing": "pending", "uds": "pending", "dbc": "pending"}
 
         # Timing Monitor
         if self.timing_monitor:
+            with self.state_lock:
+                self.status["timing"] = "running"
+
             thread = threading.Thread(
                 target=self._run_timing_monitor,
                 args=(timing_timeout,),
@@ -69,10 +85,15 @@ class MonitorManager:
             thread.start()
             print("[INFO] ✓ Timing Monitor started")
         else:
-            self.completed["timing"] = True
+            with self.state_lock:
+                self.completed["timing"] = True
+                self.status["timing"] = "skipped"
 
         # UDS Monitor
         if self.uds_monitor:
+            with self.state_lock:
+                self.status["uds"] = "running"
+
             thread = threading.Thread(
                 target=self._run_uds_monitor,
                 daemon=True,
@@ -82,10 +103,15 @@ class MonitorManager:
             thread.start()
             print("[INFO] ✓ UDS Monitor started")
         else:
-            self.completed["uds"] = True
+            with self.state_lock:
+                self.completed["uds"] = True
+                self.status["uds"] = "skipped"
 
         # DBC Monitor
         if self.dbc_monitor:
+            with self.state_lock:
+                self.status["dbc"] = "running"
+
             thread = threading.Thread(
                 target=self._run_dbc_monitor,
                 args=(dbc_timeout,),
@@ -96,79 +122,125 @@ class MonitorManager:
             thread.start()
             print("[INFO] ✓ DBC Monitor started")
         else:
-            self.completed["dbc"] = True
+            with self.state_lock:
+                self.completed["dbc"] = True
+                self.status["dbc"] = "skipped"
 
         print(f"[INFO] Total {len(self.threads)} monitor(s) running")
 
-
+    # 각 모니터 실행 함수
     def _run_timing_monitor(self, timeout: Optional[float]):
         try:
             fail_score = self.timing_monitor.start(timeout=timeout)
 
-            with self.scores_lock:
+            with self.state_lock:
+                # 이미 timeout으로 처리된 경우 덮어쓰지 않음
+                if self.status["timing"] == "timeout":
+                    return
                 self.scores["timing"] = fail_score
                 self.completed["timing"] = True
+                self.status["timing"] = "ok"
 
             print(f"[INFO] Timing Monitor completed - Score: {fail_score}")
 
         except Exception as e:
             print(f"[ERROR] Timing Monitor crashed: {e}")
-            with self.scores_lock:
+            with self.state_lock:
+                if self.status["timing"] == "timeout":
+                    return
                 self.completed["timing"] = True
-
+                self.status["timing"] = "crashed"
 
     def _run_uds_monitor(self):
         try:
             fail_score = self.uds_monitor.start()
 
-            with self.scores_lock:
+            with self.state_lock:
+                if self.status["uds"] == "timeout":
+                    return
                 self.scores["uds"] = fail_score
                 self.completed["uds"] = True
+                self.status["uds"] = "ok"
 
             print(f"[INFO] UDS Monitor completed - Score: {fail_score}")
 
         except Exception as e:
             print(f"[ERROR] UDS Monitor crashed: {e}")
-            with self.scores_lock:
+            with self.state_lock:
+                if self.status["uds"] == "timeout":
+                    return
                 self.completed["uds"] = True
-
+                self.status["uds"] = "crashed"
 
     def _run_dbc_monitor(self, timeout: Optional[float]):
         try:
             fail_score = self.dbc_monitor.start(timeout=timeout)
 
-            with self.scores_lock:
+            with self.state_lock:
+                if self.status["dbc"] == "timeout":
+                    return
                 self.scores["dbc"] = fail_score
                 self.completed["dbc"] = True
+                self.status["dbc"] = "ok"
 
             print(f"[INFO] DBC Monitor completed - Score: {fail_score}")
 
         except Exception as e:
             print(f"[ERROR] DBC Monitor crashed: {e}")
-            with self.scores_lock:
+            with self.state_lock:
+                if self.status["dbc"] == "timeout":
+                    return
                 self.completed["dbc"] = True
+                self.status["dbc"] = "crashed"
 
 
+    # 종료 대기 + timeout 처리
     def wait_for_completion(self, timeout: Optional[float] = None):
+        """
+        각 모니터 스레드가 종료될 때까지 대기.
+        timeout이 주어지면, join(timeout) 이후에도 살아있는 스레드는
+        status를 'timeout'으로 마킹하고 completed=True로 설정한다.
+        (실제 스레드를 kill 하진 못하지만, 파이프라인 관점에서는 timeout 처리)
+        """
         for name, thread in self.threads.items():
+            if not thread.is_alive():
+                continue
+
             thread.join(timeout=timeout)
-            if thread.is_alive():
-                print(f"[WARN] {name} thread is still running")
+
+            if thread.is_alive() and timeout is not None:
+                print(f"[WARN] {name} thread is still running (timeout reached)")
+                with self.state_lock:
+                    self.completed[name] = True
+                    self.status[name] = "timeout"
 
         self.running = False
-        print("[INFO] All monitors completed")
+        print("[INFO] All monitors completed (or timed out)")
 
 
+    # 상태 조회
     def is_all_completed(self) -> bool:
-        with self.scores_lock:
+        with self.state_lock:
             return all(self.completed.values())
 
     def get_completion_status(self) -> Dict[str, bool]:
-        with self.scores_lock:
+        """
+        기존 코드 호환용: 여전히 bool만 리턴
+        상세 상태는 get_status()를 통해 확인
+        """
+        with self.state_lock:
             return self.completed.copy()
 
+    def get_status(self) -> Dict[str, str]:
+        """
+        각 모니터의 상세 상태:
+        "pending" | "running" | "ok" | "timeout" | "crashed" | "skipped"
+        """
+        with self.state_lock:
+            return self.status.copy()
+
     def get_scores(self) -> Dict[str, float]:
-        with self.scores_lock:
+        with self.state_lock:
             return self.scores.copy()
 
     def is_running(self) -> bool:

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -1,16 +1,19 @@
 # src/pipeline.py
+
 import time
 import json
 from typing import Optional, Dict, Any
 
-from seeds.dbc_parser import DbcParser
-from seeds.seed_manager import SeedManager, Seed
-from seeds.seed_queue import SeedQueue
+from .seeds.dbc_parser import DbcParser
+from .seeds.seed_manager import SeedManager, Seed
+from .seeds.seed_queue import SeedQueue
 
-from monitor.monitor_manager import MonitorManager
-from monitor.timing_monitor import TimingMonitor
-from monitor.uds_monitor import UDSMonitor
-from monitor.dbc_monitor import DBCMonitor
+from .monitor.monitor_manager import MonitorManager
+from .monitor.timing_monitor import TimingMonitor
+from .monitor.uds_monitor import UDSMonitor
+from .monitor.dbc_monitor import DBCMonitor
+
+from .mutation.mutator import Mutator
 
 
 class AutoFuzzPipeline:
@@ -39,6 +42,7 @@ class AutoFuzzPipeline:
         manager.close()
         return seeds
 
+
     def __init__(self, db_path: str = "seeds.db", can_iface: Optional[object] = None):
         self.queue = SeedQueue(db_path)
         self.can = can_iface
@@ -50,66 +54,105 @@ class AutoFuzzPipeline:
             dbc_monitor=DBCMonitor()
         )
 
-    def send(self, seed: Seed):
+
+    def send_raw_payload(self, data: bytes, arb_id: int):
+        """실제 CAN raw 송신 또는 스텁 출력"""
         if not self.can:
-            arb = seed.message_id or 0x6A6
-            print(f"[Stub:Tx] ID={hex(arb)} | Signal={seed.signal_name:<25}")
+            print(f"[Stub:Tx] ID={hex(arb_id)} | Data={data.hex()}")
             return
 
         try:
-            value = int(seed.metadata.offset or 0)
-        except Exception:
-            value = 0
-
-        data = value.to_bytes(8, "little", signed=True)
-        arb = getattr(seed, "message_id", None) or getattr(self.can, "can_id", 0x6A6)
-
-        try:
-            self.can.send_raw(data, arb_id=arb)
+            self.can.send_raw(data, arb_id=arb_id)
         except Exception as e:
             print(f"[!] CAN send error: {e}")
 
+
+    def fuzz_seed(self, seed: Seed, monitor_weights: Dict[str, float]):
+        """
+        1. seed → base bytes 생성
+        2. Mutator 생성 & mutate_manager 실행
+        3. Mutated payload 각각 CAN 송신
+        """
+        try:
+            value = int(seed.metadata.offset or 0)
+            base_data = value.to_bytes(8, "little", signed=True)
+        except Exception:
+            base_data = (0).to_bytes(8, "little")
+
+        mut = Mutator(
+            data=base_data,
+            weights=monitor_weights,
+            min_length=1
+        )
+
+        mutated_list = mut.mutate_manager()
+
+        arb_id = seed.message_id or 0x6A6
+
+        for payload in mutated_list:
+            self.send_raw_payload(payload, arb_id)
+            time.sleep(0.01)
+
+
     def run(self) -> Dict[str, Any]:
         """
-        퍼징 + 모니터링을 수행하고 최종 결과 딕셔너리로 반환한다.
-        CLI 쪽에서 출력/저장하도록 함.
+        1. 모니터 시작
+        2. Seed pop
+        3. Mutator → Tx
+        4. 모니터 종료 + 결과 반환
         """
         self.running = True
 
-        # 모니터 실행
-        self.monitor_manager.start_monitors(timing_timeout=5.0)
+        # 모니터 시작
+        self.monitor_manager.start_monitors(
+            timing_timeout=5.0,
+            dbc_timeout=5.0
+        )
 
-        # CAN Listener 시작
+        # CAN listener
         if self.can:
             try:
                 self.can.start_listener()
             except Exception as e:
                 print(f"[!] CAN listener start failed: {e}")
 
-        # Fuzzing Loop
+        # mutator 초기 가중치
+        monitor_weights = {}
+
+        # fuzzing
         while self.running:
             seed = self.queue.pop()
             if not seed:
                 break
 
-            self.send(seed)
+            self.fuzz_seed(seed, monitor_weights)
             time.sleep(0.2)
 
-        # 종료 처리
         if self.can:
             self.can.stop_listener()
 
         self.monitor_manager.wait_for_completion()
 
         scores = self.monitor_manager.get_scores()
-        status = self.monitor_manager.get_completion_status()
+        completed = self.monitor_manager.get_completion_status()
+        status = self.monitor_manager.get_status()      # 상세 상태 추가
 
-        # 파이프라인 종료
         self.queue.close()
 
-        # 결과 딕셔너리 리턴
         return {
-            "timing": {"score": scores["timing"], "completed": status["timing"]},
-            "uds": {"score": scores["uds"], "completed": status["uds"]},
-            "dbc": {"score": scores["dbc"], "completed": status["dbc"]},
+            "timing": {
+                "score": scores["timing"],
+                "completed": completed["timing"],
+                "status": status["timing"],
+            },
+            "uds": {
+                "score": scores["uds"],
+                "completed": completed["uds"],
+                "status": status["uds"],
+            },
+            "dbc": {
+                "score": scores["dbc"],
+                "completed": completed["dbc"],
+                "status": status["dbc"],
+            },
         }


### PR DESCRIPTION
## 📌 PR 개요
- 모니터링 시스템 개선 및 전체 파이프라인과의 연동 구조를 대폭 정비했습니다.
- MonitorManager에 상태(status) 체계를 추가하여 모니터 결과를 더욱 명확하게 구분할 수 있도록 했습니다.
- pipeline → CLI까지 전체 흐름에서 상태 정보가 전달되도록 구조를 정리했습니다.

## 🔍 주요 변경 사항
- `MonitorManager`에 상태 필드(status: ok / timeout / crashed / skipped) 추가
- 모니터 스레드 종료 로직 개선 (`join(timeout)` 기반 timeout 처리 포함)
- `pipeline.run()`에서 status 정보를 포함하여 CLI로 전달하도록 구조 확장
- CLI `print_monitor_results()` 개선 : 아이콘 제거, 컬러 기반 상태 출력 적용

## ✅ 체크리스트
- [ ] README에 모니터 상태 체계 및 실행 구조 변경 내용 추가

## ⚠️ 기타 참고 사항
- 이번 리팩토링 이후에는 모든 실행 커맨드는 프로젝트 루트 기준 `python -m src.cli run` 형태로 실행해야 합니다.