### PR TITLE
Bugfix/config-path-fix: 패키지 import 구조 통합 및 config 기반 파이프라인으로 마이그레이션

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,0 +1,12 @@
+paths:
+  dbc: "A5.dbc"
+  seed_db: "seeds.db"
+  logs: "logs/"
+
+can:
+  channel: "vcan0"
+  default_id: "0x6A6"
+
+fuzz:
+  timing_timeout: 5.0
+  dbc_timeout: 5.0

--- a/config/loader.py
+++ b/config/loader.py
@@ -1,0 +1,15 @@
+import os
+import yaml
+
+def load_config(path: str = None) -> dict:
+    """Load config YAML. If none given, load default.yaml."""
+    base_dir = os.path.dirname(__file__)
+    default_path = os.path.join(base_dir, "default.yaml")
+
+    if path is None:
+        path = default_path
+
+    with open(path, "r", encoding="utf-8") as f:
+        cfg = yaml.safe_load(f)
+
+    return cfg

--- a/src/cli.py
+++ b/src/cli.py
@@ -3,28 +3,40 @@
 import json
 import click
 from .pipeline import AutoFuzzPipeline
+from ..config.loader import load_config
 
 
 @click.group()
 def cli():
-    """Auto-Fuzz CLI — Seed registration, listing, and fuzzing."""
     pass
 
-# 시드 등록
+
 @cli.command()
-@click.option("--dbc", required=True, type=click.Path(exists=True))
-@click.option("--db", default="seeds.db")
-def register(dbc, db):
-    click.echo(f"[+] Parsing DBC: {dbc}")
-    count = AutoFuzzPipeline.register_seeds(dbc, db)
-    click.echo(f"[✓] {count} seeds registered into '{db}'")
+@click.option("--config", default=None)
+@click.option("--dbc", default=None)
+@click.option("--db", default=None)
+def register(config, dbc, db):
+    cfg = load_config(config)
+
+    if dbc:
+        cfg["paths"]["dbc"] = dbc
+    if db:
+        cfg["paths"]["seed_db"] = db
+
+    count = AutoFuzzPipeline.register_seeds(
+        dbc_path=cfg["paths"]["dbc"],
+        db_path=cfg["paths"]["seed_db"]
+    )
+    click.echo(f"[✓] {count} seeds registered.")
 
 
-# 시드 목록 출력
 @cli.command()
-@click.option("--db", default="seeds.db")
-def list(db):
-    seeds = AutoFuzzPipeline.list_seeds(db)
+@click.option("--config", default=None)
+def list(config):
+    cfg = load_config(config)
+    db_path = cfg["paths"]["seed_db"]
+
+    seeds = AutoFuzzPipeline.list_seeds(db_path)
     if not seeds:
         click.echo("[!] No seeds found.")
         return
@@ -39,7 +51,6 @@ def list(db):
     click.echo("-" * 60)
 
 
-# 모니터 결과 UI
 def print_monitor_results(results: dict):
     click.echo(click.style("\n=== AutoFuzz Monitor Results ===\n", fg="cyan", bold=True))
 
@@ -48,7 +59,6 @@ def print_monitor_results(results: dict):
         score_val = v.get("score", 0.0)
         status = v.get("status", "unknown")
 
-        # 상태 텍스트 색상 처리
         if status == "ok":
             status_text = click.style("OK", fg="green")
         elif status == "timeout":
@@ -60,7 +70,6 @@ def print_monitor_results(results: dict):
         else:
             status_text = click.style("UNKNOWN", fg="white")
 
-        # 점수 색상
         score_text = click.style(f"{score_val:.3f}", fg="cyan")
 
         click.echo(f"{monitor:<10} | Score: {score_text} | Status: {status_text}")
@@ -68,39 +77,25 @@ def print_monitor_results(results: dict):
     click.echo()
 
 
-# 퍼저 실행
 @cli.command()
-@click.option("--db", default="seeds.db")
-@click.option("--channel", default="vcan0")
-@click.option("--can", is_flag=True)
-@click.option("--can-id", default="0x6A6")
-@click.option("--save-json", is_flag=True, help="Save monitor results to fuzz_results.json")
-def run(db, channel, can, can_id, save_json):
-    """Run Auto-Fuzz pipeline."""
+@click.option("--config", default=None)
+@click.option("--save-json", is_flag=True)
+def run(config, save_json):
+    cfg = load_config(config)
 
-    # CAN ID 파싱
-    try:
-        can_id_int = int(can_id, 16)
-        click.echo(f"[✓] Using CAN ID {hex(can_id_int)}")
-    except ValueError:
-        click.echo("[!] Invalid CAN ID format.")
-        return
-
-    # CAN 인터페이스 준비
     can_iface = None
-    if can:
-        from interface.can_interface import CANInterface
-        can_iface = CANInterface(channel=channel, can_id=can_id_int)
-        click.echo(f"[+] CAN Interface initialized on {channel}")
+    if cfg["can"].get("enable", False):
+        from .interface.can_interface import CANInterface
+        can_iface = CANInterface(
+            channel=cfg["can"]["channel"],
+            can_id=int(cfg["can"]["default_id"], 16)
+        )
 
-    # 파이프라인 실행
-    pipeline = AutoFuzzPipeline(db, can_iface=can_iface)
+    pipeline = AutoFuzzPipeline(cfg, can_iface=can_iface)
     results = pipeline.run()
 
-    # 모니터 결과 출력
     print_monitor_results(results)
 
-    # JSON 저장 옵션
     if save_json:
         with open("fuzz_results.json", "w", encoding="utf-8") as f:
             json.dump(results, f, indent=4)

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -17,6 +17,8 @@ from .mutation.mutator import Mutator
 
 
 class AutoFuzzPipeline:
+    
+    # 시드 등록
     @staticmethod
     def register_seeds(dbc_path: str, db_path: str = "seeds.db") -> int:
         parser = DbcParser(dbc_path)
@@ -35,6 +37,8 @@ class AutoFuzzPipeline:
         manager.close()
         return total
 
+    
+    # 시드 목록
     @staticmethod
     def list_seeds(db_path: str = "seeds.db"):
         manager = SeedManager(db_path)
@@ -43,18 +47,34 @@ class AutoFuzzPipeline:
         return seeds
 
 
-    def __init__(self, db_path: str = "seeds.db", can_iface: Optional[object] = None):
-        self.queue = SeedQueue(db_path)
+    # config
+    def __init__(self, cfg: Dict[str, Any], can_iface: Optional[object] = None):
+        """
+        cfg: config dict (default.yaml 또는 사용자 config)
+        """
+
+        self.cfg = cfg
         self.can = can_iface
         self.running = False
 
+        # 시드 큐 초기화
+        seed_db_path = cfg["paths"]["seed_db"]
+        self.queue = SeedQueue(seed_db_path)
+
+        # 모니터 매니저
         self.monitor_manager = MonitorManager(
             timing_monitor=TimingMonitor(),
             uds_monitor=UDSMonitor(),
-            dbc_monitor=DBCMonitor()
+            dbc_monitor=DBCMonitor(
+                channel=cfg["can"]["channel"],
+                dbc_path=cfg["paths"]["dbc"],
+                target_id=int(cfg["can"]["default_id"], 16),
+                seed_db_path=cfg["paths"]["seed_db"]
+            )
         )
 
 
+    # CAN 송신
     def send_raw_payload(self, data: bytes, arb_id: int):
         """실제 CAN raw 송신 또는 스텁 출력"""
         if not self.can:
@@ -66,13 +86,15 @@ class AutoFuzzPipeline:
         except Exception as e:
             print(f"[!] CAN send error: {e}")
 
-
+    
+    # 시드
     def fuzz_seed(self, seed: Seed, monitor_weights: Dict[str, float]):
         """
         1. seed → base bytes 생성
         2. Mutator 생성 & mutate_manager 실행
         3. Mutated payload 각각 CAN 송신
         """
+
         try:
             value = int(seed.metadata.offset or 0)
             base_data = value.to_bytes(8, "little", signed=True)
@@ -87,39 +109,44 @@ class AutoFuzzPipeline:
 
         mutated_list = mut.mutate_manager()
 
-        arb_id = seed.message_id or 0x6A6
+        arb_id = seed.message_id or int(self.cfg["can"]["default_id"], 16)
 
         for payload in mutated_list:
             self.send_raw_payload(payload, arb_id)
             time.sleep(0.01)
 
 
+    # 실행
     def run(self) -> Dict[str, Any]:
         """
+        0. config 기반 timeout 읽기
         1. 모니터 시작
-        2. Seed pop
-        3. Mutator → Tx
-        4. 모니터 종료 + 결과 반환
+        2. Seed pop → fuzz → Tx
+        3. 모니터 종료
+        4. 점수/상태 반환
         """
+
         self.running = True
 
-        # 모니터 시작
+        timing_timeout = float(self.cfg["fuzz"]["timing_timeout"])
+        dbc_timeout = float(self.cfg["fuzz"]["dbc_timeout"])
+
+        # 1. 모니터 시작
         self.monitor_manager.start_monitors(
-            timing_timeout=5.0,
-            dbc_timeout=5.0
+            timing_timeout=timing_timeout,
+            dbc_timeout=dbc_timeout
         )
 
-        # CAN listener
+        # 2. CAN Listener 시작
         if self.can:
             try:
                 self.can.start_listener()
             except Exception as e:
                 print(f"[!] CAN listener start failed: {e}")
 
-        # mutator 초기 가중치
-        monitor_weights = {}
+        monitor_weights = {}  # Mutator 가중치 (추후 확장)
 
-        # fuzzing
+        # 3. fuzz loop
         while self.running:
             seed = self.queue.pop()
             if not seed:
@@ -128,17 +155,20 @@ class AutoFuzzPipeline:
             self.fuzz_seed(seed, monitor_weights)
             time.sleep(0.2)
 
+        # 4. CAN listener 종료
         if self.can:
             self.can.stop_listener()
 
+        # 5. monitor 종료 대기
         self.monitor_manager.wait_for_completion()
 
         scores = self.monitor_manager.get_scores()
         completed = self.monitor_manager.get_completion_status()
-        status = self.monitor_manager.get_status()      # 상세 상태 추가
+        status = self.monitor_manager.get_status()
 
         self.queue.close()
 
+        # 6. 결과 리턴
         return {
             "timing": {
                 "score": scores["timing"],


### PR DESCRIPTION
## 📌 PR 개요
- 전체 프로젝트를 config 기반 구조로 리팩토링해 패키지 배포 및 실행 환경의 일관성을 확보했습니다.
- DBC 경로 하드코딩 문제를 제거하고, DBC/SeedDB/CAN 설정을 config(default.yaml) 중심으로 통일했습니다.
- CLI 명령어도 config 기반으로 통합해, `--dbc`, `--db`, `--can-id` 등의 옵션 없이 **단일 config로 전체 제어**가 가능합니다.

## 🔍 주요 변경 사항
- 패키지 import 구조 통합 리팩토링
- config 시스템 도입 (default.yaml + loader)
- DBCMonitor 하드코딩 문제 제거
- CLI 구조 정리

## ✅ 체크리스트
- [x] config.default.yaml로 실행 경로 및 설정 일관성 확보
- [ ] python -m src.cli register 정상 실행
- [ ] python -m src.cli run 정상 실행
- [ ] Windows 환경에서 모듈 import 에러 미발생

## ⚠️ 기타 참고 사항
1. CLI 명령어는 아래 세 개로 단일화됨
```bash
python -m src.cli register
python -m src.cli list
python -m src.cli run
```

2. DBC 파일(A5.dbc) 위치 필수 규칙
```markdown
auto-fuzz/
 ├── A5.dbc
 ├── seeds.db
 ├── src/
 │   └── autofuzz/
```

3. config 수정만으로 차량/환경 설정 변경 가능
CAN channel, DB 파일, DBC 버전 변경 등은 모두:
```bash
config/default.yaml
```
또는 실행 시
```bash
--config custom.yaml
```