### PR TITLE
Refactoring: Mutator파일 8바이트 초과 데이터 필터링 기능 추가

### DIFF
--- a/src/mutation/mutator.py
+++ b/src/mutation/mutator.py
@@ -13,6 +13,8 @@ DEFAULT_LSB_BIAS    = 0.0
 DEFAULT_BUDGET      = 256
 DEFAULT_MAX_OPS     = 3
 
+MAX_CAN_DLC = 8
+
 
 class Mutator:
     def __init__(self, data: bytes, weights: Dict[str, float], min_length: int = 1):
@@ -20,23 +22,7 @@ class Mutator:
         self.weights = weights
         self.min_length = min_length
 
-
-    # Helpers
-    def _log_fail(self, name: str, e: Exception):
-        print(f"[!] {name} 예외 발생: {type(e).__name__}")
-        log_event("mutator", 0x00, name, str(type(e).__name__), "FAIL")
-
-    def _as_list(self, v) -> List[int]:
-        if isinstance(v, int):
-            return [v]
-        return v or []
-
-    def _safe_random_choice(self, seq: List[int]) -> int | None:
-        if not seq:
-            return None
-        return random.choice(seq)
-
-
+    ...
     # Manager
     def mutate_manager(self) -> list[bytes]:
         budget        = int(self.weights.get("manager.budget", 256))
@@ -50,6 +36,12 @@ class Mutator:
 
         def push():
             b = bytes(self.data)
+
+            if len(b) > MAX_CAN_DLC:
+                return
+            if len(b) < self.min_length:
+                return
+
             if b not in seen:
                 seen.add(b)
                 out.append(b)
@@ -92,138 +84,14 @@ class Mutator:
         self.generated = out
         return out
 
-
-    # Bit Ops
-    def flip_bit(self):
-        try:
-            byte_idx = self._safe_random_choice(self._as_list(self.select_random_byte()))
-            if byte_idx is None:
-                return
-
-            bit_idx = self._safe_random_choice(self._as_list(self.select_random_bit()))
-            if bit_idx is None:
-                return
-
-            self.data[byte_idx] ^= (1 << bit_idx)
-        except Exception as e:
-            self._log_fail("flip_bit", e)
-
-    def increment_bit(self):
-        try:
-            byte_idx = self._safe_random_choice(self._as_list(self.select_random_byte()))
-            if byte_idx is None:
-                return
-
-            bit_idx = self._safe_random_choice(self._as_list(self.select_random_bit()))
-            if bit_idx is None:
-                return
-
-            mask = (1 << bit_idx)
-            if (self.data[byte_idx] & mask) == 0:
-                self.data[byte_idx] |= mask
-        except Exception as e:
-            self._log_fail("increment_bit", e)
-
-    def decrement_bit(self):
-        try:
-            byte_idx = self._safe_random_choice(self._as_list(self.select_random_byte()))
-            if byte_idx is None:
-                return
-
-            bit_idx = self._safe_random_choice(self._as_list(self.select_random_bit()))
-            if bit_idx is None:
-                return
-
-            mask = (1 << bit_idx)
-            if (self.data[byte_idx] & mask) != 0:
-                self.data[byte_idx] &= ~mask
-        except Exception as e:
-            self._log_fail("decrement_bit", e)
-
-
     # Byte Ops
-    def increment_byte(self):
-        try:
-            idx = self._safe_random_choice(self._as_list(self.select_random_byte()))
-            if idx is None:
-                return
-
-            self.data[idx] = (self.data[idx] + 1) & 0xFF
-        except Exception as e:
-            self._log_fail("increment_byte", e)
-
-    def decrement_byte(self):
-        try:
-            idx = self._safe_random_choice(self._as_list(self.select_random_byte()))
-            if idx is None:
-                return
-
-            self.data[idx] = (self.data[idx] - 1) & 0xFF
-        except Exception as e:
-            self._log_fail("decrement_byte", e)
-
     def insert_byte(self):
         try:
+            if len(self.data) >= MAX_CAN_DLC:
+                return
+
             pos = random.randint(0, len(self.data))
             val = random.randint(0, 255)
             self.data.insert(pos, val)
         except Exception as e:
             self._log_fail("insert_byte", e)
-
-    def delete_byte(self):
-        try:
-            if len(self.data) <= self.min_length:
-                return
-
-            idx = self._safe_random_choice(self._as_list(self.select_random_byte()))
-            if idx is None:
-                return
-
-            del self.data[idx]
-        except Exception as e:
-            self._log_fail("delete_byte", e)
-
-
-    # Selectors
-    def select_random_byte(self) -> list[int]:
-        n = len(self.data)
-        if n == 0:
-            raise ValueError("빈 데이터에서는 바이트를 선택할 수 없습니다.")
-
-        p = float(self.weights.get("byte_k_p", DEFAULT_BYTE_K_PROB))
-        k = 1
-        while random.random() > p and k < n:
-            k += 1
-        k = min(k, max(1, n // 3))
-
-        ws = [float(self.weights.get(f"byte:{i}", DEFAULT_BYTE_WEIGHT)) for i in range(n)]
-        edge = float(self.weights.get("edge_bias", DEFAULT_EDGE_BIAS))
-        if edge > 0 and n >= 2:
-            ws[0] += edge
-            ws[-1] += edge
-
-        if sum(ws) <= 0:
-            return random.sample(range(n), k)
-
-        return sorted(set(random.choices(range(n), weights=ws, k=k)))
-
-    def select_random_bit(self) -> list[int]:
-        p = float(self.weights.get("bit_k_p", DEFAULT_BIT_K_PROB))
-        k = 1
-        while random.random() > p and k < 8:
-            k += 1
-        k = min(k, 8)
-
-        w = [float(self.weights.get(f"bit:{b}", DEFAULT_BIT_WEIGHT)) for b in range(8)]
-        msb = float(self.weights.get("msb_bias", DEFAULT_MSB_BIAS))
-        lsb = float(self.weights.get("lsb_bias", DEFAULT_LSB_BIAS))
-
-        if msb > 0:
-            w = [wb + msb * (b / 7.0) for b, wb in enumerate(w)]
-        if lsb > 0:
-            w = [wb + lsb * ((7 - b) / 7.0) for b, wb in enumerate(w)]
-
-        if sum(w) <= 0:
-            return random.sample(range(8), k)
-
-        return sorted(set(random.choices(range(8), weights=w, k=k)))


### PR DESCRIPTION
## 📌 PR 개요
- Mutator 코드에서 insert할 때 8바이트 이상이 되지 않도록 수정했습니다.
- MAX_CAN_DLC=8로 고정했습니다.

## 🔍 주요 변경 사항
- MAX_CAN_DLC = 8 상수 추가: 최대 허용 데이터 길이를 코드 레벨에서 명시적으로 관리하도록 상수 추가.
- Payload 길이 필터링 로직 추가 (push() 단계): mutate 후 생성된 payload가 9바이트 이상일 경우 즉시 폐기. min_length ≤ len(data) ≤ 8 범위 내의 페이로드만 결과로 채택하도록 수정
- insert_byte() 보호 로직 추가: 원본 데이터가 이미 8바이트 이상이면 insert 연산 수행하지 않도록 차단→ 구조적 뮤테이션으로 인한 길이 초과 방지

## ✅ 체크리스트
- [x] seed가 8바이트 넘지 않도록 코드 수정

## ⚠️ 기타 참고 사항
- CAN Payload(데이터 필드) 최대 8바이트