### PR TITLE
Bugfix/mutator-8byte-filltering: 누락 코드 작성

### DIFF
--- a/src/mutation/mutator.py
+++ b/src/mutation/mutator.py
@@ -13,7 +13,8 @@ DEFAULT_LSB_BIAS    = 0.0
 DEFAULT_BUDGET      = 256
 DEFAULT_MAX_OPS     = 3
 
-MAX_CAN_DLC = 8
+# ★ CAN Classic 최대 DLC 제한
+MAX_CAN_DLC = 8  
 
 
 class Mutator:
@@ -22,11 +23,25 @@ class Mutator:
         self.weights = weights
         self.min_length = min_length
 
-    ...
+    # Helpers
+    def _log_fail(self, name: str, e: Exception):
+        print(f"[!] {name} 예외 발생: {type(e).__name__}")
+        log_event("mutator", 0x00, name, str(type(e).__name__), "FAIL")
+
+    def _as_list(self, v) -> List[int]:
+        if isinstance(v, int):
+            return [v]
+        return v or []
+
+    def _safe_random_choice(self, seq: List[int]) -> int | None:
+        if not seq:
+            return None
+        return random.choice(seq)
+
     # Manager
     def mutate_manager(self) -> list[bytes]:
-        budget        = int(self.weights.get("manager.budget", 256))
-        max_ops       = int(self.weights.get("manager.max_ops", 3))
+        budget        = int(self.weights.get("manager.budget", DEFAULT_BUDGET))
+        max_ops       = int(self.weights.get("manager.max_ops", DEFAULT_MAX_OPS))
         enable_struct = bool(self.weights.get("manager.structural", True))
         include_orig  = bool(self.weights.get("manager.include_original", False))
 
@@ -34,11 +49,15 @@ class Mutator:
         seen: set[bytes] = set()
         base = bytes(self.data)
 
+        # push() = mutate된 데이터 최종적으로 out에 넣기 전 검증 단계
         def push():
             b = bytes(self.data)
 
+            # ★ 8바이트 초과 payload 자동 필터링
             if len(b) > MAX_CAN_DLC:
                 return
+
+            # ★ mutate 후 최소 길이 유지
             if len(b) < self.min_length:
                 return
 
@@ -46,6 +65,7 @@ class Mutator:
                 seen.add(b)
                 out.append(b)
 
+        # 원본 데이터 포함 여부
         if include_orig:
             self.data = bytearray(base)
             push()
@@ -76,17 +96,87 @@ class Mutator:
                         self._log_fail(op, e)
 
                 push()
+
             except Exception as e:
                 self._log_fail("mutate_manager", e)
+
             finally:
                 self.data = saved
 
         self.generated = out
         return out
 
+    # Bit Ops
+    def flip_bit(self):
+        try:
+            byte_idx = self._safe_random_choice(self._as_list(self.select_random_byte()))
+            if byte_idx is None:
+                return
+
+            bit_idx = self._safe_random_choice(self._as_list(self.select_random_bit()))
+            if bit_idx is None:
+                return
+
+            self.data[byte_idx] ^= (1 << bit_idx)
+        except Exception as e:
+            self._log_fail("flip_bit", e)
+
+    def increment_bit(self):
+        try:
+            byte_idx = self._safe_random_choice(self._as_list(self.select_random_byte()))
+            if byte_idx is None:
+                return
+
+            bit_idx = self._safe_random_choice(self._as_list(self.select_random_bit()))
+            if bit_idx is None:
+                return
+
+            mask = (1 << bit_idx)
+            if (self.data[byte_idx] & mask) == 0:
+                self.data[byte_idx] |= mask
+        except Exception as e:
+            self._log_fail("increment_bit", e)
+
+    def decrement_bit(self):
+        try:
+            byte_idx = self._safe_random_choice(self._as_list(self.select_random_byte()))
+            if byte_idx is None:
+                return
+
+            bit_idx = self._safe_random_choice(self._as_list(self.select_random_bit()))
+            if bit_idx is None:
+                return
+
+            mask = (1 << bit_idx)
+            if (self.data[byte_idx] & mask) != 0:
+                self.data[byte_idx] &= ~mask
+        except Exception as e:
+            self._log_fail("decrement_bit", e)
+
     # Byte Ops
+    def increment_byte(self):
+        try:
+            idx = self._safe_random_choice(self._as_list(self.select_random_byte()))
+            if idx is None:
+                return
+
+            self.data[idx] = (self.data[idx] + 1) & 0xFF
+        except Exception as e:
+            self._log_fail("increment_byte", e)
+
+    def decrement_byte(self):
+        try:
+            idx = self._safe_random_choice(self._as_list(self.select_random_byte()))
+            if idx is None:
+                return
+
+            self.data[idx] = (self.data[idx] - 1) & 0xFF
+        except Exception as e:
+            self._log_fail("decrement_byte", e)
+
     def insert_byte(self):
         try:
+            # ★ 8바이트 이상이면 insert 수행 금지
             if len(self.data) >= MAX_CAN_DLC:
                 return
 
@@ -95,3 +185,60 @@ class Mutator:
             self.data.insert(pos, val)
         except Exception as e:
             self._log_fail("insert_byte", e)
+
+    def delete_byte(self):
+        try:
+            if len(self.data) <= self.min_length:
+                return
+
+            idx = self._safe_random_choice(self._as_list(self.select_random_byte()))
+            if idx is None:
+                return
+
+            del self.data[idx]
+        except Exception as e:
+            self._log_fail("delete_byte", e)
+
+    # Selectors
+    def select_random_byte(self) -> list[int]:
+        n = len(self.data)
+        if n == 0:
+            raise ValueError("빈 데이터에서는 바이트를 선택할 수 없습니다.")
+
+        p = float(self.weights.get("byte_k_p", DEFAULT_BYTE_K_PROB))
+        k = 1
+        while random.random() > p and k < n:
+            k += 1
+        k = min(k, max(1, n // 3))
+
+        ws = [float(self.weights.get(f"byte:{i}", DEFAULT_BYTE_WEIGHT)) for i in range(n)]
+        edge = float(self.weights.get("edge_bias", DEFAULT_EDGE_BIAS))
+        if edge > 0 and n >= 2:
+            ws[0] += edge
+            ws[-1] += edge
+
+        if sum(ws) <= 0:
+            return random.sample(range(n), k)
+
+        return sorted(set(random.choices(range(n), weights=ws, k=k)))
+
+    def select_random_bit(self) -> list[int]:
+        p = float(self.weights.get("bit_k_p", DEFAULT_BIT_K_PROB))
+        k = 1
+        while random.random() > p and k < 8:
+            k += 1
+        k = min(k, 8)
+
+        w = [float(self.weights.get(f"bit:{b}", DEFAULT_BIT_WEIGHT)) for b in range(8)]
+        msb = float(self.weights.get("msb_bias", DEFAULT_MSB_BIAS))
+        lsb = float(self.weights.get("lsb_bias", DEFAULT_LSB_BIAS))
+
+        if msb > 0:
+            w = [wb + msb * (b / 7.0) for b, wb in enumerate(w)]
+        if lsb > 0:
+            w = [wb + lsb * ((7 - b) / 7.0) for b, wb in enumerate(w)]
+
+        if sum(w) <= 0:
+            return random.sample(range(8), k)
+
+        return sorted(set(random.choices(range(8), weights=w, k=k)))

--- a/src/mutation/mutator.py
+++ b/src/mutation/mutator.py
@@ -13,9 +13,7 @@ DEFAULT_LSB_BIAS    = 0.0
 DEFAULT_BUDGET      = 256
 DEFAULT_MAX_OPS     = 3
 
-# ★ CAN Classic 최대 DLC 제한
 MAX_CAN_DLC = 8  
-
 
 class Mutator:
     def __init__(self, data: bytes, weights: Dict[str, float], min_length: int = 1):
@@ -49,15 +47,12 @@ class Mutator:
         seen: set[bytes] = set()
         base = bytes(self.data)
 
-        # push() = mutate된 데이터 최종적으로 out에 넣기 전 검증 단계
         def push():
             b = bytes(self.data)
 
-            # ★ 8바이트 초과 payload 자동 필터링
             if len(b) > MAX_CAN_DLC:
                 return
 
-            # ★ mutate 후 최소 길이 유지
             if len(b) < self.min_length:
                 return
 
@@ -65,7 +60,6 @@ class Mutator:
                 seen.add(b)
                 out.append(b)
 
-        # 원본 데이터 포함 여부
         if include_orig:
             self.data = bytearray(base)
             push()
@@ -176,7 +170,6 @@ class Mutator:
 
     def insert_byte(self):
         try:
-            # ★ 8바이트 이상이면 insert 수행 금지
             if len(self.data) >= MAX_CAN_DLC:
                 return
 


### PR DESCRIPTION
## 📌 PR 개요
- 어제 수정코드가 수정된 부분만 있는 코드였어서 다시 모두 합쳤습니다.

## 🔍 주요 변경 사항
- mutator 코드 누락 부분 작성

## ✅ 체크리스트
- [x] seed가 8바이트 넘지 않도록 코드 수정

## ⚠️ 기타 참고 사항
- CAN Payload(데이터 필드) 최대 8바이트