### PR TITLE
Feature/UDS_monitor_score-refact: 스코어 가중치 변경

### DIFF
--- a/src/monitor/uds_monitor.py
+++ b/src/monitor/uds_monitor.py
@@ -6,7 +6,6 @@ import isotp
 import yaml
 from ..logger.base_logger import log_event
 
-
 # 모니터링 설정값
 
 CAN_CHANNEL = "can0"
@@ -26,10 +25,9 @@ isotp_params = {
 }
 
 # 스코어 가중치 설정
-SCORE_NO_RESPONSE_0x10 = 1.0   # 세션 진입 실패 (가장 치명적)
-SCORE_NO_RESPONSE_0x3E = 0.8   # Tester Present 실패
+SCORE_NO_RESPONSE_0x10 = 0.8   # 세션 진입 실패 (가장 치명적)
+SCORE_NO_RESPONSE_0x3E = 0.6   # Tester Present 실패
 MAX_DTC_COUNT = 20              # DTC 개수 정규화 기준 (20개 이상이면 1.0)
-
 
 
 # NRC config 로드


### PR DESCRIPTION
## 📌 PR 개요
- UDS 모니터링 로직의 안정성을 높이기 위해 세션 진입 무응답(0x10) 및 Tester Present(0x3E) 무응답 스코어 가중치를 조정했습니다.
- 실제 테스트 환경에서 응답 없음(no response) 상황을 더 명확하게 반영할 수 있도록 점수를 재설계했습니다.

## 🔍 주요 변경 사항
- SCORE_NO_RESPONSE_0x10 값을 1.0 → 0.8으로 조정
- SCORE_NO_RESPONSE_0x3E 값을 0.8 → 0.6으로 조정

## ✅ 체크리스트
- [ ] FAIL 스코어 누적 로직이 새로운 가중치와 정상적으로 연동되는지 확인
- [ ] 세션 진입 실패 발생 시 스코어가 의도한 수준(0.8)으로 적용되는지 검증

## ⚠️ 기타 참고 사항
- 현재는 두 이벤트에 대한 스코어만 조정했으며, 전체 NRC 값은 기존 스케일 그대로 유지합니다.