### PR TITLE
Refactor/dbc-monitor: dbc 모니터 min, max값 Raw value 변환

### DIFF
--- a/src/monitor/dbc_monitor.py
+++ b/src/monitor/dbc_monitor.py
@@ -191,7 +191,9 @@ class DBCMonitor:
                 self._update_fail_score()
                 raise RuntimeError(f"enum 위반: {sig} value={val}, 허용={enum_vals}")
 
-        mn, mx = rule.get("min"), rule.get("max")
+        sigmn, sigmx = rule.get("min"), rule.get("max")
+        factor, offset = rule.get("factor"), rule.get("offset")
+        mn, mx = (sigmn - offset) / factor , (sigmx - offset) / factor
 
         if mn is not None:
             self._total_checks += 1


### PR DESCRIPTION
## 📌 PR 개요
- DBC 기반 range 검사 로직에서 physical value 기준 비교를 하던 부분을
  raw value 기준 비교로 수정했습니다.

## 🔍 주요 변경 사항
- DBCMonitor의 range 체크 로직 수정
   - 기존 : 디코드 된 값을 physical value 기준 min/max와 비교
   - 변경 : 디코드 된 값을 raw value 기준 min/max와 비교 

## ✅ 체크리스트
- [ ] 실차에서 기본 동작 확인

## ⚠️ 기타 참고 사항
- DBC min/max 값이 모두 physical 기준으로 정의되어 있음을 고려해, raw value 값으로 비교하도록 로직 변경