### PR TITLE
Feature/uds_monitor_refact : 특정 NRC가 발생하면 세부 구분 없이 fail = 1로 처리

### DIFF
--- a/config/nrc_weights.yaml
+++ b/config/nrc_weights.yaml
@@ -1,9 +1,9 @@
-nrc_scores:
-  "0x10": 50
-  "0x11": 30
-  "0x12": 40
-  "0x13": 60
-  "0x22": 70
-  "0x31": 50
-  "0x33": 80
-  "0x72": 40
+nrc_fail_list:
+  - "0x11"  # ServiceNotSupported
+  - "0x12"  # SubFunctionNotSupported
+  - "0x13"  # IncorrectMessageLengthOrInvalidFormat
+  - "0x14"  # ResponseTooLong
+  - "0x24"  # RequestSequenceError
+  - "0x31"  # RequestOutOfRange
+  - "0x70"  # UploadDownloadNotAccepted
+  - "0x72"  # GeneralProgrammingFailure

--- a/src/monitor/uds_monitor.py
+++ b/src/monitor/uds_monitor.py
@@ -32,7 +32,7 @@ MAX_DTC_COUNT = 20              # DTC 개수 정규화 기준 (20개 이상이�
 
 # NRC config 로드
 
-def load_nrc_config(path: str):
+def load_nrc_fail_list(path: str):
     if not os.path.exists(path):
         raise FileNotFoundError(f"NRC config not found: {path}")
 
@@ -42,25 +42,24 @@ def load_nrc_config(path: str):
     if not isinstance(data, dict) or "nrc_scores" not in data:
         raise ValueError("Invalid NRC config: missing 'nrc_scores'")
 
-    scores = {}
-    for k, v in data["nrc_scores"].items():
+    fail_set = set()
+    for item in data["nrc_fail_list"]:
         try:
-            key = int(k, 16) if isinstance(k, str) and k.startswith("0x") else int(k)
-            scores[key] = float(v)
+            nrc = int(item, 16) if isinstance(item, str) else int(item)
+            fail_set.add(nrc)
         except Exception as e:
-            raise ValueError(f"Invalid NRC key/value {k}:{v} ({e})")
-    return scores
+            raise ValueError(f"Invalid NRC value {item} ({e})")
+
+    return fail_set
 
 
 
 # UDS 모니터 클래스
 
 class UDSMonitor:
-    def __init__(self, nrc_cfg_path: str = "config/nrc_weights.yaml"):
-        # NRC 점수 테이블 로드
-        self.NRC_CLASS = load_nrc_config(nrc_cfg_path)
+    def __init__(self, nrc_cfg_path: str = "config/nrc_fail_list.yaml"):
+        self.NRC_FAIL_SET = load_nrc_fail_list(nrc_cfg_path)
 
-        # CAN & ISO-TP 초기화
         self.bus = can.interface.Bus(channel=CAN_CHANNEL, bustype="socketcan")
         addr = isotp.Address(
             isotp.AddressingMode.Normal_11bits,
@@ -68,8 +67,7 @@ class UDSMonitor:
             rxid=TARGET_UDS_ID + UDS_RESPONSE_OFFSET
         )
         self.stack = isotp.CanStack(bus=self.bus, address=addr, params=isotp_params)
-        
-        # FAIL 스코어 누적 (0~1 범위)
+
         self._fail_score = 0.0
 
 
@@ -167,14 +165,12 @@ class UDSMonitor:
         # NRC 응답
         if resp[0] == 0x7F:
             nrc = resp[2]
-            if nrc in self.NRC_CLASS:
-                score = self.NRC_CLASS[nrc]
-                self._fail_score += score
-                log_event("uds", TARGET_UDS_ID, f"NRC_{hex(nrc)}", score, "FAIL")
+            if nrc in self.NRC_FAIL_SET:
+                self._fail_score = 1.0
+                log_event("uds", TARGET_UDS_ID, f"NRC_{hex(nrc)}", "fail_list_hit", "FAIL")
                 return False
             else:
-                # 알 수 없는 NRC는 정상으로 처리
-                log_event("uds", TARGET_UDS_ID, f"NRC_unknown_{hex(nrc)}", nrc, "WARN")
+                log_event("uds", TARGET_UDS_ID, f"NRC_{hex(nrc)}", "ignored", "WARN")
                 return True
 
         # 정상 응답
@@ -202,10 +198,9 @@ class UDSMonitor:
             # NRC 응답
             elif resp[0] == 0x7F:
                 nrc = resp[2]
-                if nrc in self.NRC_CLASS:
-                    score = self.NRC_CLASS[nrc]
-                    self._fail_score += score
-                    log_event("uds", TARGET_UDS_ID, f"DTC_NRC_{hex(nrc)}", score, "FAIL")
+                if nrc in self.NRC_FAIL_SET:
+                    self._fail_score = 1.0
+                    log_event("uds", TARGET_UDS_ID, f"DTC_NRC_{hex(nrc)}", "fail_list_hit", "FAIL")
                 else:
                     log_event("uds", TARGET_UDS_ID, "DTC_NRC_Unknown", nrc, "WARN")
                 continue

--- a/src/monitor/uds_monitor.py
+++ b/src/monitor/uds_monitor.py
@@ -39,8 +39,8 @@ def load_nrc_fail_list(path: str):
     with open(path, "r", encoding="utf-8") as f:
         data = yaml.safe_load(f)
 
-    if not isinstance(data, dict) or "nrc_scores" not in data:
-        raise ValueError("Invalid NRC config: missing 'nrc_scores'")
+    if not isinstance(data, dict) or "nrc_fail_list" not in data:
+        raise ValueError("Invalid NRC config: missing 'nrc_fail_list'")
 
     fail_set = set()
     for item in data["nrc_fail_list"]:
@@ -170,7 +170,7 @@ class UDSMonitor:
                 log_event("uds", TARGET_UDS_ID, f"NRC_{hex(nrc)}", "fail_list_hit", "FAIL")
                 return False
             else:
-                log_event("uds", TARGET_UDS_ID, f"NRC_{hex(nrc)}", "ignored", "WARN")
+                log_event("uds", TARGET_UDS_ID, f"NRC_unknown_{hex(nrc)}", nrc, "WARN")
                 return True
 
         # 정상 응답


### PR DESCRIPTION
## 📌 PR 개요
- NRC 처리 로직을 단순화했습니다.
- 특정 NRC가 발생하면 세부 구분 없이 fail = 1로 처리되도록 변경했습니다.

## 🔍 주요 변경 사항
- nrc_fail_list에 포함된 NRC 발생 시 score를 일괄적으로 1로 처리
- NRC별 개별 점수 계산 로직 제거

## ✅ 체크리스트

## ⚠️ 기타 참고 사항
- 본 변경은 nrc 처리를 단순화하기 위한 것으로, NRC 종류 간의 상대적 중요도는 현재 고려하지 않습니다.