### PR TITLE
Add: 재현 A 파트 구현 (factory, mutation_engine, pipeline_candidate)

### DIFF
--- a/src/seeds/factory.py
+++ b/src/seeds/factory.py
@@ -1,0 +1,97 @@
+# src/seeds/factory.py
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from .seed_manager import Seed
+
+MAX_CAN_DLC = 8
+
+
+def _clamp_dlc(dlc: int) -> int:
+    if dlc < 0:
+        return 0
+    return min(dlc, MAX_CAN_DLC)
+
+
+def build_initial_seeds_from_parsed_dbc(
+    parsed_dbc: Dict[str, Any],
+    *,
+    default_priority: int = 0,
+) -> List[Seed]:
+    """
+    DbcParser.parse() 결과(dict)를 받아 초기 후보(Seed) 리스트를 생성.
+    - 메시지(frame) 단위로 1개씩 생성
+    - payload는 기본으로 dlc 길이만큼 0x00
+    """
+    out: List[Seed] = []
+
+    for msg in parsed_dbc.get("messages", []):
+        arb_id = int(msg["id"])
+        dlc = _clamp_dlc(int(msg.get("dlc", 8)))
+        is_ext = bool(msg.get("is_extended_frame", False))
+
+        payload = bytes([0x00] * dlc)
+
+        meta = {
+            "msg_name": msg.get("name"),
+            "dlc": dlc,
+            "is_extended": is_ext,
+            "comment": msg.get("comment"),
+            "cycle_time": msg.get("cycle_time"),
+        }
+
+        out.append(
+            Seed(
+                arb_id=arb_id,
+                payload=payload,
+                dlc=dlc,
+                is_extended=is_ext,
+                parent_id=None,
+                root_id=None,
+                depth=0,
+                priority=default_priority,
+                status="queued",
+                meta=meta,
+            )
+        )
+
+    return out
+
+
+def build_child_seed(
+    parent: Seed,
+    *,
+    payload: bytes,
+    priority_delta: int = 0,
+    status: str = "queued",
+    extra_meta: Optional[Dict[str, Any]] = None,
+) -> Seed:
+    """
+    parent Seed로부터 child Seed 생성 규칙.
+    - parent_id/depth/root_id/priority/meta를 자동 구성
+    """
+    assert parent.id is not None, "build_child_seed: parent.id is None (parent must be loaded from DB)"
+
+    dlc = _clamp_dlc(parent.dlc if parent.dlc is not None else len(payload))
+    child_payload = payload[:dlc]
+
+    pr = int(parent.priority) + int(priority_delta)
+
+    meta = dict(parent.meta or {})
+    meta.update({"parent": parent.id, "depth": parent.depth + 1})
+    if extra_meta:
+        meta.update(extra_meta)
+
+    return Seed(
+        arb_id=parent.arb_id,
+        payload=child_payload,
+        dlc=dlc,
+        is_extended=parent.is_extended,
+        parent_id=parent.id,
+        root_id=parent.root_id,
+        depth=parent.depth + 1,
+        priority=pr,
+        status=status,
+        meta=meta,
+    )

--- a/src/seeds/mutation_engine.py
+++ b/src/seeds/mutation_engine.py
@@ -1,0 +1,47 @@
+# src/seeds/mutation_engine.py
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from .seed_manager import Seed, SeedManager
+from .factory import build_child_seed
+from ..mutation.mutator import Mutator
+
+class MutationEngine:
+    """
+    parent Seed -> mutated payloads -> child Seed insert -> new child ids 반환
+    """
+
+    def __init__(self, seed_manager: SeedManager):
+        self.sm = seed_manager
+
+    def mutate_and_store_children(
+        self,
+        parent: Seed,
+        *,
+        weights: Optional[Dict[str, float]] = None,
+        min_length: int = 1,
+        priority_delta: int = 0,
+        extra_meta: Optional[dict] = None,
+    ) -> List[int]:
+        weights = weights or {}
+
+        base_payload = bytes(parent.payload or b"")[: int(parent.dlc)]
+        mut = Mutator(data=base_payload, weights=weights, min_length=min_length)
+        mutated_payloads = mut.mutate_manager()
+
+        new_ids: List[int] = []
+        for p in mutated_payloads:
+            child = build_child_seed(
+                parent,
+                payload=p,
+                priority_delta=priority_delta,
+                status="queued",
+                extra_meta=extra_meta,
+            )
+
+            new_id = self.sm.insert_seed(child)  # dedup이면 None
+            if new_id is not None:
+                new_ids.append(int(new_id))
+
+        return new_ids

--- a/src/seeds/pipeline_candidate.py
+++ b/src/seeds/pipeline_candidate.py
@@ -1,0 +1,117 @@
+# src/seeds/pipeline_candidate.py
+from __future__ import annotations
+
+import time
+from typing import Dict, Optional
+
+from .seed_manager import SeedManager
+from .seed_queue import SeedQueue
+from .tx_log import TxLog, TxFrame
+from .mutation_engine import MutationEngine
+
+
+class CandidatePipeline:
+    def __init__(
+        self,
+        *,
+        cfg: Dict,
+        can_iface: object,
+        seed_manager: SeedManager,
+        seed_queue: SeedQueue,
+        tx_log: TxLog,
+        mutation_engine: MutationEngine,
+    ):
+        self.cfg = cfg
+        self.can = can_iface
+        self.sm = seed_manager
+        self.q = seed_queue
+        self.txlog = tx_log
+        self.mut = mutation_engine
+        self.running = False
+
+    def run(
+        self,
+        *,
+        max_iters: Optional[int] = None,
+        per_send_gap_s: float = 0.01,
+        per_seed_gap_s: float = 0.2,
+        mutation_weights: Optional[Dict[str, float]] = None,
+    ) -> int:
+        """
+        반환: 처리(전송 시도)한 seed 개수
+        """
+        self.running = True
+        done = 0
+        iters = 0
+
+        can_cfg = self.cfg.get("can", {})
+        force_default_id = bool(can_cfg.get("force_default_id", True))
+        default_id = int(can_cfg.get("default_id", "0x6A6"), 16)
+
+        while self.running:
+            if max_iters is not None and iters >= max_iters:
+                break
+            iters += 1
+
+            # 1) pop: (seed_queue 테이블에서 claim=DELETE)
+            seed_id = self.q.pop()
+            if seed_id is None:
+                break
+
+            seed = self.sm.get_seed(seed_id)
+            if seed is None:
+                # DB에서 사라졌거나 이상한 상태면 error 처리
+                self.sm.update_status(seed_id, "error")
+                continue
+
+            # 2) frame 결정
+            arb_id = default_id if force_default_id else int(seed.arb_id)
+            payload = bytes(seed.payload or b"")[: int(seed.dlc)]
+            dlc = int(seed.dlc)
+            is_ext = bool(seed.is_extended)
+
+            frame = TxFrame(
+                arb_id=arb_id,
+                payload=payload,
+                dlc=dlc,
+            )
+
+            # 3) CAN send
+            try:
+                self.can.send_raw(frame.payload, arb_id=frame.arb_id, is_extended=is_ext)
+            except Exception:
+                self.sm.update_status(seed_id, "error")
+                continue
+
+            # 4) tx_log + anchor
+            try:
+                send_idx = self.txlog.append(frame, seed_id=seed_id)
+                self.sm.set_last_send_idx(seed_id, send_idx)
+            except Exception:
+                send_idx = None  # tx_log 실패해도 퍼징은 계속
+
+            # 5) 전송 성공 처리
+            self.sm.update_status(seed_id, "sent")
+            done += 1
+            time.sleep(per_send_gap_s)
+
+            # 6) mutation -> child 생성/저장 -> queue push
+            try:
+                child_ids = self.mut.mutate_and_store_children(
+                    seed,
+                    weights=mutation_weights or {},
+                    min_length=1,
+                    priority_delta=0,
+                    extra_meta={"anchor_send_idx": send_idx} if send_idx is not None else None,
+                )
+                for cid in child_ids:
+                    self.q.push(cid)  # seed_queue 테이블에 INSERT OR IGNORE
+            except Exception:
+                pass
+
+            time.sleep(per_seed_gap_s)
+
+        return done
+
+    def stop(self) -> None:
+        self.running = False


### PR DESCRIPTION
## 📌 PR 개요
- Candidate A 파트 모듈 3종(factory / mutation_engine / pipeline_candidate)을 구현했습니다.
- SeedManager/SeedQueue/TxLog와 호환되도록 Candidate 생성 → 변이 → 전송 → tx_log 앵커 기록 → 자식 후보 큐잉까지 기본 루프를 구성했습니다.

## 🔍 주요 변경 사항
- src/seeds/factory.py
	- DBC parse 결과로 초기 후보 리스트 생성 (arb_id/dlc 기반, payload는 0x00 채움)
	- parent → child Seed 생성 규칙 구현
	- parent.id가 없는 경우를 방지하기 위해 assert parent.id is not None 가드 추가
	- priority clamp 제거 (현재는 parent.priority + priority_delta 그대로 사용)
- src/seeds/mutation_engine.py
	- 기존 Mutator.mutate_manager() 연동하여 변이 payload 생성
	- 변이 결과를 child Seed로 생성 후 SeedManager.insert_seed()로 저장
	- dedup(UNIQUE + INSERT OR IGNORE) 기반으로 중복 후보 자동 스킵
	- 새로 삽입된 child id만 반환(큐잉용)
- src/seeds/pipeline_candidate.py
	- DB 기반 큐(SeedQueue.pop())로 후보 pop(queued→picked) 후 전송 루프 구현
	- CAN 전송(CANInterface.send_raw) + 전송 로그 기록(TxLog.append) + last_send_idx 앵커 업데이트
	- mutation → child 생성 → SeedQueue.push()로 큐잉까지 연결
	- 디버깅/실험용으로 max_iters(후보 처리 개수 제한) 옵션 지원

## ✅ 체크리스트
- [x] SeedManager/SeedQueue/TxLog와 API 호환 확인 (insert_seed / pop / push / append / set_last_send_idx)
- [ ] dedup 동작 시 중복 후보가 자동으로 스킵되는 구조 확인
- [ ] 기존 pipeline.py에서 CandidatePipeline 호출하도록 연결 (연결부 작업 필요)


## ⚠️ 기타 참고 사항
- priority clamp는 현재 제거된 버전입니다. 만약 범위 제한이 필요하면 factory.build_child_seed()에서 clamp를 다시 추가하거나, cfg 기반 상한/하한으로 확장 가능합니다.
- CAN 전송 실패 시 현재는 status=error로 마킹하고 재시도는 하지 않습니다. 필요 시 재시도/재큐잉으로 확장 가능합니다.