### PR TITLE
Add: 재현 A파트 seeds

### DIFF
--- a/src/seeds/seed_manager.py
+++ b/src/seeds/seed_manager.py
@@ -1,18 +1,23 @@
-# src/seeds/seed_manager.py
+from __future__ import annotations
+
 import json
 import sqlite3
+import hashlib
 from dataclasses import dataclass, field
-from typing import Any, List, Optional, Dict
+from typing import Any, Dict, List, Optional
+
+
+def _sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
 
 
 @dataclass
 class SignalMeta:
-    """Signal 관련 세부 메타데이터 구조"""
     start_bit: Optional[int] = None
     length: Optional[int] = None
     byte_order: Optional[str] = None
     is_signed: Optional[bool] = None
-    factor: Optional[float] = None      # scale → factor로 변경
+    factor: Optional[float] = None
     offset: Optional[float] = None
     minimum: Optional[float] = None
     maximum: Optional[float] = None
@@ -22,80 +27,327 @@ class SignalMeta:
 
 @dataclass
 class Seed:
-    """단일 Signal을 나타내는 Seed"""
-    message_id: int
-    signal_name: str
+    message_id: Optional[int] = None
+    signal_name: str = ""
     desc: str = ""
     priority: int = 1
     metadata: SignalMeta = field(default_factory=SignalMeta)
     id: Optional[int] = None
 
+    arb_id: Optional[int] = None
+    payload: bytes = b""
+    dlc: int = 8
+    is_extended: bool = False
+
+    parent_id: Optional[int] = None
+    root_id: Optional[int] = None
+    depth: int = 0
+    status: str = "queued"
+    meta: Dict[str, Any] = field(default_factory=dict)
+    last_send_idx: Optional[int] = None
+
+    repro_verdict: Optional[str] = None
+    repro_rate: Optional[float] = None
+    last_evidence: Optional[str] = None
+    repro_json: Optional[Dict[str, Any]] = None
+
+    fingerprint: Optional[str] = None
+
+    def ensure_candidate_defaults(self) -> None:
+        if self.arb_id is None and self.message_id is not None:
+            self.arb_id = int(self.message_id)
+        if self.message_id is None and self.arb_id is not None:
+            self.message_id = int(self.arb_id)
+        if self.dlc is None:
+            self.dlc = len(self.payload or b"")
+        if not self.payload:
+            self.payload = bytes([0x00] * int(self.dlc))
+        if self.fingerprint is None:
+            self.fingerprint = _sha256_hex(bytes(self.payload or b""))
+
 
 class SeedManager:
-    """Seed Pool 관리 및 DB 연동 클래스"""
-
     def __init__(self, db_path: str = "seeds.db"):
         self.conn = sqlite3.connect(db_path)
+        self.conn.row_factory = sqlite3.Row
         self._create_table()
+        self._migrate()
 
     def _create_table(self):
-        query = """
-        CREATE TABLE IF NOT EXISTS seeds (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            message_id INTEGER,
-            signal_name TEXT,
-            desc TEXT,
-            priority INTEGER,
-            metadata TEXT
-        );
-        """
-        self.conn.execute(query)
+        self.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS seeds (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+
+                message_id INTEGER,
+                signal_name TEXT,
+                desc TEXT,
+                priority INTEGER NOT NULL DEFAULT 1,
+                metadata TEXT,
+
+                arb_id INTEGER,
+                payload BLOB,
+                dlc INTEGER DEFAULT 8,
+                is_extended INTEGER NOT NULL DEFAULT 0,
+
+                parent_id INTEGER,
+                root_id INTEGER,
+                depth INTEGER NOT NULL DEFAULT 0,
+                status TEXT NOT NULL DEFAULT 'queued',
+                meta_json TEXT,
+
+                last_send_idx INTEGER,
+
+                repro_verdict TEXT,
+                repro_rate REAL,
+                last_evidence TEXT,
+                repro_json TEXT,
+
+                fingerprint TEXT,
+
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+            """
+        )
         self.conn.commit()
 
+    def _migrate(self):
+        self._ensure_column("seeds", "arb_id", "INTEGER")
+        self._ensure_column("seeds", "payload", "BLOB")
+        self._ensure_column("seeds", "dlc", "INTEGER DEFAULT 8")
+        self._ensure_column("seeds", "is_extended", "INTEGER NOT NULL DEFAULT 0")
+        self._ensure_column("seeds", "parent_id", "INTEGER")
+        self._ensure_column("seeds", "root_id", "INTEGER")
+        self._ensure_column("seeds", "depth", "INTEGER NOT NULL DEFAULT 0")
+        self._ensure_column("seeds", "status", "TEXT NOT NULL DEFAULT 'queued'")
+        self._ensure_column("seeds", "meta_json", "TEXT")
+        self._ensure_column("seeds", "last_send_idx", "INTEGER")
+        self._ensure_column("seeds", "repro_verdict", "TEXT")
+        self._ensure_column("seeds", "repro_rate", "REAL")
+        self._ensure_column("seeds", "last_evidence", "TEXT")
+        self._ensure_column("seeds", "repro_json", "TEXT")
+        self._ensure_column("seeds", "fingerprint", "TEXT")
+
+        self.conn.execute(
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS uq_seeds_candidate_dedup
+            ON seeds(arb_id, dlc, fingerprint);
+            """
+        )
+        self.conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_seeds_priority
+            ON seeds(priority DESC, id ASC);
+            """
+        )
+        self.conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_seeds_status_priority
+            ON seeds(status, priority DESC, id ASC);
+            """
+        )
+        self.conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_seeds_root
+            ON seeds(root_id);
+            """
+        )
+        self.conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_seeds_parent
+            ON seeds(parent_id);
+            """
+        )
+        self.conn.commit()
+
+    def _ensure_column(self, table: str, col: str, col_type: str):
+        rows = self.conn.execute(f"PRAGMA table_info({table});").fetchall()
+        existing_cols = {row["name"] for row in rows}
+        if col not in existing_cols:
+            self.conn.execute(f"ALTER TABLE {table} ADD COLUMN {col} {col_type};")
+            self.conn.commit()
+
     def add_seed(self, seed: Seed) -> int:
-        """새로운 Seed를 DB에 추가"""
-        query = """
-        INSERT INTO seeds (message_id, signal_name, desc, priority, metadata)
-        VALUES (?, ?, ?, ?, ?);
-        """
+        seed.ensure_candidate_defaults()
+
         cur = self.conn.execute(
-            query,
+            """
+            INSERT INTO seeds (
+                message_id, signal_name, desc, priority, metadata,
+                arb_id, payload, dlc, is_extended,
+                parent_id, root_id, depth, status, meta_json,
+                last_send_idx,
+                repro_verdict, repro_rate, last_evidence, repro_json,
+                fingerprint
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+            """,
             (
                 seed.message_id,
                 seed.signal_name,
                 seed.desc,
                 seed.priority,
-                json.dumps(seed.metadata.__dict__),
+                self._dump_signal_meta(seed.metadata),
+                seed.arb_id,
+                bytes(seed.payload or b""),
+                int(seed.dlc),
+                1 if seed.is_extended else 0,
+                seed.parent_id,
+                seed.root_id,
+                int(seed.depth),
+                seed.status,
+                json.dumps(seed.meta or {}, ensure_ascii=False),
+                seed.last_send_idx,
+                seed.repro_verdict,
+                seed.repro_rate,
+                seed.last_evidence,
+                json.dumps(seed.repro_json, ensure_ascii=False) if seed.repro_json is not None else None,
+                seed.fingerprint,
             ),
         )
         self.conn.commit()
-        return cur.lastrowid
+
+        new_id = int(cur.lastrowid)
+
+        if seed.root_id is None:
+            root_id = seed.parent_id if seed.parent_id is not None else new_id
+            if seed.parent_id is not None:
+                parent = self.get_seed(seed.parent_id)
+                if parent is not None and parent.root_id is not None:
+                    root_id = parent.root_id
+            self.conn.execute(
+                "UPDATE seeds SET root_id = ?, updated_at = datetime('now') WHERE id = ?",
+                (root_id, new_id),
+            )
+            self.conn.commit()
+
+        return new_id
+
+    def insert_seed(self, seed: Seed) -> Optional[int]:
+        seed.ensure_candidate_defaults()
+
+        cur = self.conn.execute(
+            """
+            INSERT OR IGNORE INTO seeds (
+                message_id, signal_name, desc, priority, metadata,
+                arb_id, payload, dlc, is_extended,
+                parent_id, root_id, depth, status, meta_json,
+                last_send_idx,
+                repro_verdict, repro_rate, last_evidence, repro_json,
+                fingerprint
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+            """,
+            (
+                seed.message_id,
+                seed.signal_name,
+                seed.desc,
+                seed.priority,
+                self._dump_signal_meta(seed.metadata),
+                seed.arb_id,
+                bytes(seed.payload or b""),
+                int(seed.dlc),
+                1 if seed.is_extended else 0,
+                seed.parent_id,
+                seed.root_id,
+                int(seed.depth),
+                seed.status,
+                json.dumps(seed.meta or {}, ensure_ascii=False),
+                seed.last_send_idx,
+                seed.repro_verdict,
+                seed.repro_rate,
+                seed.last_evidence,
+                json.dumps(seed.repro_json, ensure_ascii=False) if seed.repro_json is not None else None,
+                seed.fingerprint,
+            ),
+        )
+        self.conn.commit()
+
+        if cur.rowcount == 0:
+            return None
+
+        new_id = int(cur.lastrowid)
+
+        if seed.root_id is None:
+            root_id = seed.parent_id if seed.parent_id is not None else new_id
+            if seed.parent_id is not None:
+                parent = self.get_seed(seed.parent_id)
+                if parent is not None and parent.root_id is not None:
+                    root_id = parent.root_id
+            self.conn.execute(
+                "UPDATE seeds SET root_id = ?, updated_at = datetime('now') WHERE id = ?",
+                (root_id, new_id),
+            )
+            self.conn.commit()
+
+        return new_id
 
     def get_all(self) -> List[Seed]:
-        """DB에 등록된 모든 Seed 반환 (우선순위 기준 정렬)"""
         rows = self.conn.execute(
-            "SELECT id, message_id, signal_name, desc, priority, metadata FROM seeds ORDER BY priority DESC"
+            """
+            SELECT *
+            FROM seeds
+            ORDER BY priority DESC, id ASC
+            """
         ).fetchall()
+        return [self._row_to_seed(row) for row in rows]
 
-        seeds: List[Seed] = []
-        for row in rows:
-            meta_dict = json.loads(row[5]) if row[5] else {}
-            metadata = SignalMeta(**meta_dict)
-            seeds.append(
-                Seed(
-                    id=row[0],
-                    message_id=row[1],
-                    signal_name=row[2],
-                    desc=row[3],
-                    priority=row[4],
-                    metadata=metadata,
-                )
-            )
-        return seeds
+    def get_seed(self, seed_id: int) -> Optional[Seed]:
+        row = self.conn.execute(
+            "SELECT * FROM seeds WHERE id = ?",
+            (seed_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return self._row_to_seed(row)
 
     def update_priority(self, seed_id: int, new_priority: int):
         self.conn.execute(
-            "UPDATE seeds SET priority = ? WHERE id = ?", (new_priority, seed_id)
+            "UPDATE seeds SET priority = ?, updated_at = datetime('now') WHERE id = ?",
+            (new_priority, seed_id),
+        )
+        self.conn.commit()
+
+    def update_status(self, seed_id: int, new_status: str):
+        self.conn.execute(
+            "UPDATE seeds SET status = ?, updated_at = datetime('now') WHERE id = ?",
+            (new_status, seed_id),
+        )
+        self.conn.commit()
+
+    def set_last_send_idx(self, seed_id: int, send_idx: int):
+        self.conn.execute(
+            "UPDATE seeds SET last_send_idx = ?, updated_at = datetime('now') WHERE id = ?",
+            (send_idx, seed_id),
+        )
+        self.conn.commit()
+
+    def save_repro_summary(
+        self,
+        seed_id: int,
+        repro_verdict: str,
+        repro_rate: float,
+        last_evidence: Optional[str] = None,
+    ):
+        self.conn.execute(
+            """
+            UPDATE seeds
+            SET repro_verdict = ?, repro_rate = ?, last_evidence = ?, updated_at = datetime('now')
+            WHERE id = ?
+            """,
+            (repro_verdict, repro_rate, last_evidence, seed_id),
+        )
+        self.conn.commit()
+
+    def save_repro_report(self, seed_id: int, repro_report: Dict[str, Any]):
+        self.conn.execute(
+            """
+            UPDATE seeds
+            SET repro_json = ?, updated_at = datetime('now')
+            WHERE id = ?
+            """,
+            (json.dumps(repro_report, ensure_ascii=False), seed_id),
         )
         self.conn.commit()
 
@@ -106,10 +358,47 @@ class SeedManager:
     def close(self):
         self.conn.close()
 
-    # 메시지 단위 그룹 반환 (List[List[Seed]])
+    def _dump_signal_meta(self, metadata: Any) -> str:
+        if isinstance(metadata, SignalMeta):
+            return json.dumps(metadata.__dict__, ensure_ascii=False)
+        if isinstance(metadata, dict):
+            return json.dumps(metadata, ensure_ascii=False)
+        return json.dumps({}, ensure_ascii=False)
+
+    def _row_to_seed(self, row: sqlite3.Row) -> Seed:
+        metadata_raw = row["metadata"]
+        metadata_dict = json.loads(metadata_raw) if metadata_raw else {}
+        meta_json_raw = row["meta_json"]
+        meta_dict = json.loads(meta_json_raw) if meta_json_raw else {}
+        repro_json_raw = row["repro_json"]
+        repro_dict = json.loads(repro_json_raw) if repro_json_raw else None
+
+        return Seed(
+            id=row["id"],
+            message_id=row["message_id"],
+            signal_name=row["signal_name"] or "",
+            desc=row["desc"] or "",
+            priority=row["priority"],
+            metadata=SignalMeta(**metadata_dict),
+            arb_id=row["arb_id"],
+            payload=bytes(row["payload"]) if row["payload"] is not None else b"",
+            dlc=row["dlc"] if row["dlc"] is not None else 8,
+            is_extended=bool(row["is_extended"]) if row["is_extended"] is not None else False,
+            parent_id=row["parent_id"],
+            root_id=row["root_id"],
+            depth=row["depth"] if row["depth"] is not None else 0,
+            status=row["status"] or "queued",
+            meta=meta_dict,
+            last_send_idx=row["last_send_idx"],
+            repro_verdict=row["repro_verdict"],
+            repro_rate=row["repro_rate"],
+            last_evidence=row["last_evidence"],
+            repro_json=repro_dict,
+            fingerprint=row["fingerprint"],
+        )
+
     @staticmethod
     def from_dbc(parsed_dbc: Dict[str, Any]) -> List[List["Seed"]]:
-        """DbcParser.parse() 결과(dict)를 메시지 단위 Seed 그룹으로 변환"""
         grouped_seeds: List[List[Seed]] = []
 
         for msg in parsed_dbc.get("messages", []):
@@ -130,11 +419,22 @@ class SeedManager:
                 )
                 seed = Seed(
                     message_id=msg["id"],
+                    arb_id=msg["id"],
                     signal_name=sig["name"],
                     desc=f"Signal {sig['name']} in {msg['name']}",
                     priority=1,
                     metadata=meta,
+                    dlc=int(msg.get("dlc", 8)),
+                    is_extended=bool(msg.get("is_extended_frame", False)),
+                    payload=bytes([0x00] * int(msg.get("dlc", 8))),
+                    depth=0,
+                    status="queued",
+                    meta={
+                        "msg_name": msg.get("name"),
+                        "signal_name": sig.get("name"),
+                    },
                 )
+                seed.ensure_candidate_defaults()
                 message_group.append(seed)
 
             grouped_seeds.append(message_group)

--- a/src/seeds/seed_queue.py
+++ b/src/seeds/seed_queue.py
@@ -1,96 +1,83 @@
-# src/seeds/seed_queue.py
-
 import heapq
 import itertools
-from typing import List, Optional
-from ..seeds.seed_manager import Seed, SeedManager
+from typing import List, Optional, Union
+
+from .seed_manager import Seed, SeedManager
 
 
 class SeedQueue:
-    """
-    개선된 우선순위 기반 Seed 큐
-    - 우선순위(priority)가 같을 때 Seed 객체끼리 비교하는 문제 해결
-    - tiebreaker(counter) 사용하여 Heap 안정성 보장
-    """
-
     def __init__(self, db_path: str = "seeds.db"):
         self.manager = SeedManager(db_path)
-
-        # tiebreaker counter
         self._counter = itertools.count()
-
-        # tuple 구조: ( -priority, tiebreaker, Seed )
-        self.queue: List[tuple[int, int, Seed]] = []
-
+        self.queue: List[tuple[int, int, int]] = []
         self.load_from_db()
 
-
-    # Load all seeds from DB into the priority heap
     def load_from_db(self):
-        """DB에서 모든 Seed 로드 → 메모리 큐에 적재"""
+        self.queue.clear()
+        self._counter = itertools.count()
+
         for seed in self.manager.get_all():
+            if seed.id is None:
+                continue
+            if seed.status != "queued":
+                continue
             tiebreaker = next(self._counter)
-            heapq.heappush(self.queue, (-seed.priority, tiebreaker, seed))
-
-
-    # Push single seed
-    def push(self, seed: Seed):
-        """단일 Seed 추가"""
-
-        seed_id = self.manager.add_seed(seed)
-        seed.id = seed_id
+            heapq.heappush(self.queue, (-seed.priority, tiebreaker, seed.id))
+            
+    def push(self, seed_or_id: Union[Seed, int]):
+        if isinstance(seed_or_id, Seed):
+            seed_id = self.manager.add_seed(seed_or_id)
+            seed_or_id.id = seed_id
+            priority = seed_or_id.priority
+        else:
+            seed_id = int(seed_or_id)
+            seed = self.manager.get_seed(seed_id)
+            if seed is None:
+                return
+            priority = seed.priority
 
         tiebreaker = next(self._counter)
-        heapq.heappush(self.queue, (-seed.priority, tiebreaker, seed))
+        heapq.heappush(self.queue, (-priority, tiebreaker, seed_id))
 
-
-    # Push group of seeds (message-level)
     def push_group(self, seeds: List[Seed]):
-        """메시지 단위 Seed 그룹을 모두 추가"""
         for seed in seeds:
             self.push(seed)
 
-
-    # Pop highest priority seed
-    def pop(self) -> Optional[Seed]:
-        """가장 우선순위 높은 Seed 꺼내기"""
+    def pop(self) -> Optional[int]:
         if not self.queue:
             return None
 
-        _, _, seed = heapq.heappop(self.queue)
-        return seed
+        _, _, seed_id = heapq.heappop(self.queue)
+        return seed_id
 
-
-    # Update seed priority and reorder heap
     def update_priority(self, seed_id: int, delta: int):
-        """특정 Seed 우선순위 갱신 및 큐 재정렬"""
-
         updated = False
 
-        for i, (priority, tiebreaker, seed) in enumerate(self.queue):
-            if seed.id == seed_id:
+        for i, (priority, tiebreaker, queued_seed_id) in enumerate(self.queue):
+            if queued_seed_id == seed_id:
+                seed = self.manager.get_seed(seed_id)
+                if seed is None:
+                    return
 
-                # update priority value
-                seed.priority = max(1, min(seed.priority + delta, 10))
-                self.manager.update_priority(seed.id, seed.priority)
-
-                # replace heap entry
-                self.queue[i] = (-seed.priority, tiebreaker, seed)
-
+                new_priority = max(1, min(seed.priority + delta, 10))
+                self.manager.update_priority(seed_id, new_priority)
+                self.queue[i] = (-new_priority, tiebreaker, seed_id)
                 updated = True
                 break
 
         if updated:
             heapq.heapify(self.queue)
 
-
-    # Return list of seeds sorted by priority
     def list(self) -> List[Seed]:
-        """현재 큐 상태 반환 (우선순위 높은 순서)"""
-        sorted_list = sorted(self.queue, key=lambda x: (x[0], x[1]))
-        return [seed for _, _, seed in sorted_list]
+        sorted_queue = sorted(self.queue, key=lambda x: (x[0], x[1]))
+        out: List[Seed] = []
 
+        for _, _, seed_id in sorted_queue:
+            seed = self.manager.get_seed(seed_id)
+            if seed is not None:
+                out.append(seed)
 
-    # Close DB manager
+        return out
+
     def close(self):
         self.manager.close()

--- a/src/seeds/tx_log.py
+++ b/src/seeds/tx_log.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, List
+
+from .seed_manager import SeedManager
+
+
+@dataclass(frozen=True)
+class TxFrame:
+    arb_id: int
+    payload: bytes
+    dlc: int = 8
+
+
+class TxLog:
+    def __init__(self, seed_manager: SeedManager) -> None:
+        self.sm = seed_manager
+        self._create_table()
+
+    def _create_table(self) -> None:
+        self.sm.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS tx_log (
+                send_idx INTEGER PRIMARY KEY AUTOINCREMENT,
+                ts TEXT NOT NULL DEFAULT (datetime('now')),
+                arb_id INTEGER NOT NULL,
+                payload BLOB NOT NULL,
+                dlc INTEGER NOT NULL,
+                seed_id INTEGER NULL,
+                FOREIGN KEY(seed_id) REFERENCES seeds(id)
+            );
+            """
+        )
+        self.sm.conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_txlog_seed ON tx_log(seed_id, send_idx);"
+        )
+        self.sm.conn.commit()
+
+    def append(self, frame: TxFrame, seed_id: Optional[int] = None) -> int:
+        cur = self.sm.conn.cursor()
+        cur.execute(
+            """
+            INSERT INTO tx_log (arb_id, payload, dlc, seed_id)
+            VALUES (?, ?, ?, ?);
+            """,
+            (
+                frame.arb_id,
+                frame.payload,
+                frame.dlc,
+                seed_id,
+            ),
+        )
+        self.sm.conn.commit()
+        return int(cur.lastrowid)
+
+    def get_window(self, anchor_send_idx: int, pre: int, post: int) -> List[TxFrame]:
+        start = max(1, anchor_send_idx - max(0, pre))
+        end = anchor_send_idx + max(0, post)
+
+        rows = self.sm.conn.execute(
+            """
+            SELECT arb_id, payload, dlc
+            FROM tx_log
+            WHERE send_idx BETWEEN ? AND ?
+            ORDER BY send_idx ASC;
+            """,
+            (start, end),
+        ).fetchall()
+
+        frames: List[TxFrame] = []
+        for r in rows:
+            frames.append(
+                TxFrame(
+                    arb_id=int(r["arb_id"]),
+                    payload=bytes(r["payload"]),
+                    dlc=int(r["dlc"]),
+                )
+            )
+        return frames


### PR DESCRIPTION
## 📌 PR 개요

이번 PR에서는 **Seed 기반 퍼징 파이프라인의 기본 인프라를 구성하기 위한 모듈들을 추가/확장**했습니다.

주요 목적은 다음과 같습니다.

- DBC 기반으로 생성한 초기 Seed를 저장하고 관리할 수 있도록 `Seed_Manager` 확장
- 우선순위 기반으로 Seed를 선택할 수 있도록 `Seed_Queue` 구현
- CAN 전송 기록을 저장하고, 이후 재현(Reproduction) 과정에서 활용할 수 있도록 `TxLog` 추가

이를 통해 초기 Seed 생성 이후의 기본 흐름을 다음과 같이 구성할 수 있습니다.

    DBC Seed 생성
       ↓
    SeedManager 저장
       ↓
    SeedQueue 등록
       ↓
    CandidatePipeline에서 Seed 선택
       ↓
    CAN frame 전송
       ↓
    TxLog에 전송 기록 저장
       ↓
    Mutation을 통해 child seed 생성 및 재등록

즉, 이번 PR은 **퍼징 루프를 구성하기 위한 Seed 관리 / 우선순위 스케줄링 / 전송 로그 기록 기능을 추가한 PR**입니다.

---

## 🔍 주요 변경 사항

### 1. `src/seeds/seed_manager.py`

기존 DBC 기반 Seed 관리 구조를 유지하면서, 퍼징 파이프라인에서 사용할 수 있도록 Seed 관리 기능을 확장했습니다.

#### 포함 내용
- DBC Parser 결과로부터 초기 Seed 생성 기능 유지
- Seed DB 저장 및 조회 기능 제공
- priority 기반 관리 기능 유지
- Reproduction 결과 저장을 위한 필드 추가
  - `repro_verdict`
  - `repro_rate`
  - `last_evidence`
  - `repro_json`
- Candidate 실행에 필요한 정보 관리가 가능하도록 확장
  - `arb_id`
  - `payload`
  - `dlc`
  - `is_extended`
  - `parent_id`
  - `root_id`
  - `depth`
  - `priority`
  - `meta`
  - `last_send_idx`
  - `fingerprint`
- 기존 DB와의 호환을 위해 migration 로직 추가

#### 기대 효과
- DBC 기반 초기 Seed와 퍼징 과정에서 생성되는 child seed를 같은 manager에서 관리 가능
- Reproduction 결과를 Seed 단위로 저장 가능
- 이후 pipeline / reproducer와 연동 가능한 구조 마련

---

### 2. `src/seeds/seed_queue.py`

Seed 실행 순서를 관리하기 위한 **priority 기반 queue**를 구현했습니다.

#### 포함 내용
- `heapq` 기반 우선순위 큐 사용
- priority가 높은 Seed를 먼저 선택
- priority가 동일할 경우 안정적인 순서를 보장하기 위해 `tiebreaker(counter)` 적용
- Seed 객체 push 지원
- seed id 기반 push 지원
- pop 시 실행할 seed id 반환
- DB에 저장된 Seed를 초기 로딩하여 queue 구성 가능

#### 기대 효과
- 퍼징 루프에서 어떤 Seed를 먼저 실행할지 결정 가능
- priority 기반 스케줄링 정책 적용 가능
- child seed를 queue에 다시 등록하는 흐름 지원

---

### 3. `src/seeds/tx_log.py`

CAN 전송 기록을 저장하기 위한 **TxLog 모듈**을 추가했습니다.

#### 포함 내용
- CAN frame 전송 시 로그 저장
- `append()` 호출 시 `send_idx` 반환
- 특정 전송 시점을 기준으로 주변 frame 복원 가능
  - `get_window(anchor_send_idx, pre, post)`

#### 기대 효과
- 전송 이력을 기준으로 재현 시점 anchor 확보 가능
- 이후 reproduction 단계에서 pre/post window replay에 활용 가능
- 특정 fail 발생 시점 전후의 CAN 통신 흐름 복원 가능

---

## ⚙️ 파이프라인 관점에서의 의미

이번 PR은 퍼징 과정에서 아래 기능들이 이어질 수 있도록 기반을 마련합니다.

1. DBC로부터 초기 Seed 생성
2. Seed_Manager에 저장
3. Seed_Queue에 등록
4. Candidate_Pipeline에서 Seed 선택
5. CAN frame 전송
6. Tx_Log에 전송 기록 저장
7. Mutation_Engine을 통해 child seed 생성
8. child seed를 다시 Seed_Queue에 등록

즉, **단순한 Seed 저장을 넘어서 실제 퍼징 루프를 돌릴 수 있는 구조를 만드는 작업**입니다.

---

## ✅ 체크리스트

- [x] DBC 기반 Seed 생성 로직 유지
- [x] Seed DB 저장 및 조회 기능 동작 확인
- [x] SeedQueue priority scheduling 동작 확인
- [x] TxLog append 및 send_idx 반환 동작 확인
- [x] Mutation 이후 child seed 저장/재등록 흐름 반영
- [ ] 실제 차량 CAN 환경에서 end-to-end 테스트

---

## ⚠️ 참고 사항

- 이번 PR은 **퍼징 파이프라인의 기본 인프라 구성**에 초점을 맞춘 변경입니다.
- TxLog는 이후 Reproduction 단계에서 **CAN 환경 replay를 위한 anchor 정보**로 사용될 예정입니다.
- Reproduction 세부 판정 로직, evidence fusion, fail classification 등은 이후 PR에서 이어서 다룰 예정입니다.

---
