### PR TITLE
Add: 재현 B 파트 구현 (candidate, storage)

### DIFF
--- a/src/repro/candidate.py
+++ b/src/repro/candidate.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+class CandidateParseError(ValueError):
+    pass
+
+def parse_can_id(v: Any) -> int:
+    if isinstance(v, int):
+        return v
+    if isinstance(v, str):
+        s = v.strip().lower()
+        if s.startswith("0x"):
+            return int(s, 16)
+        try:
+            return int(s)
+        except ValueError as e:
+            raise CandidateParseError(f"Invalid CAN ID string: {v}") from e
+    raise CandidateParseError(f"Invalid type for arb_id: {type(v)}")
+
+def parse_payload(s: Any) -> bytes:
+    if not isinstance(s, str):
+        raise CandidateParseError("payload must be hex string")
+    v = s.strip().lower().replace(" ", "").replace(":", "").replace("-", "")
+    if v.startswith("0x"):
+        v = v[2:]
+    if not v:
+        raise CandidateParseError("payload hex string is empty")
+    try:
+        return bytes.fromhex(v)
+    except ValueError as e:
+        raise CandidateParseError(f"Invalid payload hex string: {s}") from e
+
+def sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+@dataclass
+class CandidateSnapshot:
+    arb_id: int
+    payload: bytes
+    dlc: int
+    id: int
+    priority: Optional[int] = None
+    parent_id: Optional[int] = None
+    root_id: Optional[int] = None
+    depth: Optional[int] = None
+    monitor_json: Optional[Dict[str, Any]] = None
+    repro_verdict: Optional[str] = None
+    repro_rate: Optional[float] = None
+    last_evidence: Optional[Any] = None
+    repro_json: Optional[Dict[str, Any]] = None
+    last_send_idx: Optional[int] = None
+    fingerprint: Optional[str] = None
+
+    @staticmethod
+    def from_dict(d: Dict[str, Any]) -> "CandidateSnapshot":
+        if not isinstance(d, dict):
+            raise CandidateParseError("Candidate JSON root must be an object(dict)")
+
+        cid = d.get("id")
+        if cid is None:
+            raise CandidateParseError("Missing required field: id")
+
+        arb_id = parse_can_id(d.get("arb_id"))
+        payload = parse_payload(d.get("payload"))
+        dlc = d.get("dlc", len(payload))
+        last_send_idx = d.get("last_send_idx")
+        priority = d.get("priority")
+        depth = d.get("depth")
+        parent_id = d.get("parent_id")
+        root_id = d.get("root_id")
+        monitor_json = d.get("monitor_json")
+        repro_verdict = d.get("repro_verdict")
+        repro_rate = d.get("repro_rate")
+        last_evidence = d.get("last_evidence")
+        repro_json = d.get("repro_json")
+
+        # fingerprint
+        fp = d.get("fingerprint")
+        if fp is None:
+            fp = sha256_hex(payload)
+        else:
+            fp = str(fp).strip().lower()
+
+        return CandidateSnapshot(
+            arb_id=arb_id,
+            payload=payload,
+            dlc=dlc,
+            id=cid,
+            priority=priority,
+            parent_id=parent_id,
+            root_id=root_id,
+            depth=depth,
+            monitor_json=monitor_json,
+            repro_verdict=str(repro_verdict) if repro_verdict is not None else None,
+            repro_rate=float(repro_rate) if repro_rate is not None else None,
+            last_evidence=last_evidence,
+            repro_json=repro_json,
+            last_send_idx=last_send_idx,
+            fingerprint=fp,
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        fp = self.fingerprint or sha256_hex(self.payload)
+
+        return {
+            "id": self.id,
+            "arb_id": self.arb_id,
+            "payload": self.payload.hex(),
+            "dlc": self.dlc,
+            "priority": self.priority,
+            "parent_id": self.parent_id,
+            "root_id": self.root_id,
+            "depth": self.depth,
+            "monitor_json": self.monitor_json,
+            "repro_verdict": self.repro_verdict,
+            "repro_rate": self.repro_rate,
+            "last_evidence": self.last_evidence,
+            "repro_json": self.repro_json,
+            "last_send_idx": self.last_send_idx,
+            "fingerprint": fp,
+        }

--- a/src/repro/storage.py
+++ b/src/repro/storage.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, is_dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional, Union
+
+from .candidate import CandidateSnapshot
+
+JsonDict = Dict[str, Any]
+
+class StorageIOError(RuntimeError):
+    pass
+
+class ReproStorage:
+    def __init__(self, artifacts_root: Union[str, Path] = "artifacts") -> None:
+        self.root = Path(artifacts_root)
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    def _sid(self, seed_id: Union[str, int]) -> str:
+        s = str(seed_id).strip()
+        if not s:
+            raise ValueError("seed_id must be non-empty")
+        return s
+
+    def artifact_dir(self, seed_id: Union[str, int]) -> Path:
+        p = self.root / "repro" / self._sid(seed_id)
+        p.mkdir(parents=True, exist_ok=True)
+        return p
+
+    def candidate_path(self, seed_id: Union[str, int]) -> Path:
+        return self.artifact_dir(seed_id) / "candidate.json"
+
+    def report_path(self, seed_id: Union[str, int], name: str) -> Path:
+        return self.artifact_dir(seed_id) / name
+
+    def _dump_json(self, path: Path, obj: Any) -> None:
+        try:
+            if is_dataclass(obj):
+                obj = asdict(obj)
+            text = json.dumps(obj, ensure_ascii=False, indent=2)
+        except Exception:
+            text = json.dumps({"_raw": str(obj)}, ensure_ascii=False, indent=2)
+
+        try:
+            path.write_text(text, encoding="utf-8")
+        except Exception as e:
+            raise StorageIOError(f"Failed to write: {path}") from e
+
+    def _load_json(self, path: Path) -> Any:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except Exception as e:
+            raise StorageIOError(f"Failed to read: {path}") from e
+
+        try:
+            return json.loads(text)
+        except Exception as e:
+            raise StorageIOError(f"Invalid JSON: {path}") from e
+
+    def save_candidate(self, seed_id: Union[str, int], c: CandidateSnapshot) -> Path:
+        p = self.candidate_path(seed_id)
+        self._dump_json(p, c.to_dict())
+        return p
+
+    def load_candidate(self, seed_id: Union[str, int]) -> CandidateSnapshot:
+        p = self.candidate_path(seed_id)
+        d = self._load_json(p)
+        if not isinstance(d, dict):
+            raise StorageIOError(f"candidate.json must be a JSON object: {p}")
+        return CandidateSnapshot.from_dict(d)
+
+    def _report_name(self, seed_id: Union[str, int]) -> str:
+        d = self.artifact_dir(seed_id)
+        n = 1
+
+        for f in d.glob("report_*.json"):
+            stem = f.stem
+            try:
+                suffix = stem.split("_", 1)[1]
+                if suffix.isdigit():
+                    n = max(n, int(suffix) + 1)
+            except (IndexError, ValueError):
+                pass
+
+        return f"report_{n:03d}.json"
+
+    def save_report(
+        self,
+        seed_id: Union[str, int],
+        report: Any,
+        *,
+        name: Optional[str] = None,
+    ) -> Path:
+        fname = name or self._report_name(seed_id)
+        p = self.report_path(seed_id, fname)
+        self._dump_json(p, report)
+        return p
+
+    def load_report(self, seed_id: Union[str, int], name: str) -> JsonDict:
+        p = self.report_path(seed_id, name)
+        d = self._load_json(p)
+        if not isinstance(d, dict):
+            raise StorageIOError(f"report must be a JSON object: {p}")
+        return d
+
+    def latest_report(self, seed_id: Union[str, int]) -> Optional[Path]:
+        d = self.artifact_dir(seed_id)
+        latest: Optional[Path] = None
+        max_n = 0
+
+        for f in d.glob("report_*.json"):
+            stem = f.stem
+            try:
+                suffix = stem.split("_", 1)[1]
+                if suffix.isdigit():
+                    n = int(suffix)
+                    if n > max_n:
+                        max_n = n
+                        latest = f
+            except (IndexError, ValueError):
+                pass
+
+        return latest


### PR DESCRIPTION
## 📌 PR 개요
- repro 파트의 기본 데이터 모델과 저장 레이어를 구현했습니다.
- `src/repro/candidate.py`에 CandidateSnapshot 및 candidate 파싱/직렬화 로직을 추가했습니다.
- `src/repro/storage.py`에 seed별 artifact 저장/로드를 담당하는 ReproStorage를 추가했습니다.
- 이를 통해 candidate JSON 저장/복원, report 순번 저장, latest report 조회까지 repro 기본 루프를 구성했습니다.


## 🔎 주요 변경 사항
- `src/repro/candidate.py`
    - `CandidateParseError` 추가
        - candidate 파싱 중 입력 형식 오류를 명확히 구분하기 위한 예외 클래스 추가
    - `parse_can_id(v)` 구현
        - CAN ID 정수형으로 정규화
    - `parse_payload(s)` 구현
        - payload hex string을 `bytes`로 변환
    - `sha256_hex(data)` 구현
        - payload 기준 fingerprint 생성용 SHA-256 헬퍼 추가
    - `CandidateSnapshot` dataclass 구현
    - `CandidateSnapshot.from_dict(d)` 구현
        - `arb_id`, `payload` 파싱 정규화
    - `CandidateSnapshot.to_dict()` 구현
        - `CandidateSnapshot` → JSON 저장 가능한 dict로 변환

- `src/repro/storage.py`
    - `StorageIOError` 추가
        - artifact 저장/로드 중 파일 I/O 및 JSON 파싱 오류를 storage 레벨 예외로 통일
    - `ReproStorage` 구현
        - repro artifact 전용 저장/로드 레이어 추가
    - seed별 artifact 디렉토리 구조 정의
        - `artifacts/repro/<seed_id>/` 형태 사용
    - Path helper 구현
    - JSON 공통 저장/로드 유틸 구현
    - candidate 저장/로드 구현
        - `save_candidate(seed_id, c)`
        - `load_candidate(seed_id)`
    - report 저장 파일명 생성 구현
        - `_report_name(seed_id)`
    - report 저장/로드 구현
        - `save_report(seed_id, report, name=None)`
        - `load_report(seed_id, name)`
    - 최신 report 조회 구현
        - `latest_report(seed_id)`
        

## ✅ 체크리스트
- [x]  `CandidateSnapshot` 기준 JSON 직렬화/역직렬화 구조 확인
- [x]  CAN ID / payload 파싱 로직 추가 및 기본 동작 확인
- [x]  fingerprint 자동 생성 로직 반영
- [x]  seed별 artifact 디렉토리 생성 및 candidate 저장/로드 확인
- [ ]  report 순번 저장(`report_001.json`, `report_002.json` ...) 동작 확인
- [x]  `latest_report()`가 가장 큰 번호의 report를 반환하는 구조 반영


## ⚠️ 기타 참고 사항
- report는 실행 이력 보존을 위해 `report_<NNN>.json` 형식으로 누적 저장되도록 구성했습니다.
- 현재 storage는 **candidate 1개 + report 여러 개 누적 저장** 정책을 기준으로 설계했습니다.
- reproducer에서 `save_candidate()` / `save_report()`를 호출하도록 연결하면 seed 단위 artifact 관리가 가능해집니다.