### PR TITLE
Feature/ reproduction : 재현 코드 추가

### DIFF
--- a/src/repro/evidence_fusion.py
+++ b/src/repro/evidence_fusion.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+from .report import ResultFrame, MONITOR_NAMES
+
+PASS      = "PASS"
+SOFT_FAIL = "SOFT_FAIL"
+HARD_FAIL = "HARD_FAIL"
+
+_DEFAULT_SOFT = 0.3
+_DEFAULT_HARD = 0.7
+
+_DEFAULT_WEIGHTS: Dict[str, float] = {
+    "timing": 0.3,
+    "uds":    0.4,
+    "dbc":    0.3,
+}
+
+
+@dataclass
+class FusionResult:
+    verdict: str            # PASS / SOFT_FAIL / HARD_FAIL
+    fusion_score: float     # 0.0 ~ 1.0
+    repro_rate: float
+    detail: Dict[str, float]  # monitor별 기여도
+
+
+class EvidenceFusion:
+    """
+    ResultFrame -> verdict + fusion_score 계산.
+
+    mode='binary':
+        fusion_score = repro_rate
+        threshold 비교로 verdict 결정
+
+    mode='weight':
+        fusion_score = sum((w_i / sum_w) * mean_score_i)
+        threshold 비교로 verdict 결정
+    """
+
+    def __init__(
+        self,
+        mode: str = "binary",
+        soft_threshold: float = _DEFAULT_SOFT,
+        hard_threshold: float = _DEFAULT_HARD,
+        weights: Optional[Dict[str, float]] = None,
+    ) -> None:
+        if mode not in ("binary", "weight"):
+            raise ValueError(f"mode는 'binary' 또는 'weight' 중 하나여야 합니다. got={mode!r}")
+        if soft_threshold >= hard_threshold:
+            raise ValueError(
+                f"soft_threshold({soft_threshold}) < hard_threshold({hard_threshold}) 이어야 합니다."
+            )
+        self.mode = mode
+        self.soft_threshold = soft_threshold
+        self.hard_threshold = hard_threshold
+        self.weights = weights or dict(_DEFAULT_WEIGHTS)
+
+    # ------------------------------------------------------------------
+
+    def evaluate(self, frame: ResultFrame) -> FusionResult:
+        if self.mode == "binary":
+            return self._binary(frame)
+        return self._weighted(frame)
+
+    # ------------------------------------------------------------------
+
+    def _verdict(self, score: float) -> str:
+        if score >= self.hard_threshold:
+            return HARD_FAIL
+        if score >= self.soft_threshold:
+            return SOFT_FAIL
+        return PASS
+
+    def _mean(self, frame: ResultFrame, name: str) -> float:
+        """MonitorSummary 인스턴스 또는 dict 모두 처리"""
+        s = frame.monitor_summary.get(name)
+        if s is None:
+            return 0.0
+        return s.mean_score if hasattr(s, "mean_score") else float(s.get("mean_score", 0.0))
+
+    def _binary(self, frame: ResultFrame) -> FusionResult:
+        rr = frame.reproduction_rate
+        detail = {name: self._mean(frame, name) for name in MONITOR_NAMES}
+        return FusionResult(
+            verdict=self._verdict(rr),
+            fusion_score=round(rr, 4),
+            repro_rate=rr,
+            detail=detail,
+        )
+
+    def _weighted(self, frame: ResultFrame) -> FusionResult:
+        total_w = sum(self.weights.get(m, 0.0) for m in MONITOR_NAMES)
+        if total_w <= 0:
+            raise ValueError("weights 합이 0 이하입니다.")
+
+        detail: Dict[str, float] = {}
+        score = 0.0
+        for name in MONITOR_NAMES:
+            w = self.weights.get(name, 0.0)
+            contrib = (w / total_w) * self._mean(frame, name)
+            detail[name] = round(contrib, 4)
+            score += contrib
+
+        score = round(min(score, 1.0), 4)
+        return FusionResult(
+            verdict=self._verdict(score),
+            fusion_score=score,
+            repro_rate=frame.reproduction_rate,
+            detail=detail,
+        )

--- a/src/repro/report.py
+++ b/src/repro/report.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from typing import Any, Dict, List, Optional
+
+# 파이프라인 전체에서 monitor 이름 순서 통일
+MONITOR_NAMES: tuple[str, ...] = ("timing", "uds", "dbc")
+
+_FAIL_STATUSES = frozenset({"crashed", "timeout"})
+
+
+@dataclass
+class MonitorSummary:
+    name: str
+    fail_count: int         # 몇 번의 trial에서 fail 판정
+    fail_bitmap: List[int]  # 길이 n, trial별 1(fail) / 0(pass)
+    scores: List[float]     # trial별 원시 score
+    mean_score: float       # 평균 score
+
+
+@dataclass
+class ResultFrame:
+    seed_id: int
+    trials: int                             # n
+    reproduced: int                         # k: 하나 이상의 monitor가 fail한 trial 수
+    reproduction_rate: float                # k / n
+    monitor_summary: Dict[str, MonitorSummary]
+    trial_results: List[Dict[str, Any]]     # per-trial raw (top_n 적용 후)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "seed_id": self.seed_id,
+            "trials": self.trials,
+            "reproduced": self.reproduced,
+            "reproduction_rate": self.reproduction_rate,
+            "monitor_summary": {
+                name: asdict(s) if isinstance(s, MonitorSummary) else dict(s)
+                for name, s in self.monitor_summary.items()
+            },
+            "trial_results": self.trial_results,
+        }
+
+    @staticmethod
+    def from_trial_results(
+        seed_id: int,
+        trial_results: List[Dict[str, Any]],
+        *,
+        top_n: Optional[int] = None,
+    ) -> "ResultFrame":
+        
+        n = len(trial_results)
+        if n == 0:
+            return ResultFrame(
+                seed_id=seed_id, trials=0, reproduced=0,
+                reproduction_rate=0.0, monitor_summary={}, trial_results=[],
+            )
+
+        summaries: Dict[str, MonitorSummary] = {}
+        for name in MONITOR_NAMES:
+            scores: List[float] = []
+            bitmap: List[int] = []
+
+            for tr in trial_results:
+                mv = tr.get(name, {})
+                score = float(mv.get("score", 0.0))
+                status = str(mv.get("status", "ok"))
+                scores.append(score)
+                bitmap.append(1 if (score > 0.0 or status in _FAIL_STATUSES) else 0)
+
+            summaries[name] = MonitorSummary(
+                name=name,
+                fail_count=sum(bitmap),
+                fail_bitmap=bitmap,
+                scores=scores,
+                mean_score=round(sum(scores) / n, 4),
+            )
+
+        # 하나 이상의 monitor가 fail한 trial 수 (k)
+        reproduced = sum(
+            1 for i in range(n)
+            if any(summaries[m].fail_bitmap[i] for m in MONITOR_NAMES)
+        )
+
+        return ResultFrame(
+            seed_id=seed_id,
+            trials=n,
+            reproduced=reproduced,
+            reproduction_rate=round(reproduced / n, 4),
+            monitor_summary=summaries,
+            trial_results=trial_results if top_n is None else trial_results[:top_n],
+        )

--- a/src/repro/reproducer.py
+++ b/src/repro/reproducer.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, List, Optional, Protocol, Tuple, runtime_checkable
+
+from .candidate import CandidateSnapshot
+from .evidence_fusion import EvidenceFusion, FusionResult
+from .report import ResultFrame
+from .storage import ReproStorage
+
+
+@runtime_checkable
+class TxLog(Protocol):
+
+    def get_frame_window(
+        self,
+        center_idx: int,
+        pre: int,
+        post: int,
+    ) -> List[Tuple[int, bytes]]: ...
+
+
+class Reproducer:
+
+
+    def __init__(
+        self,
+        can_iface,
+        monitor_manager,
+        storage: ReproStorage,
+        fusion: Optional[EvidenceFusion] = None,
+        *,
+        tx_log: Optional[TxLog] = None,
+        pre_window: int = 5,
+        post_window: int = 2,
+        trial_gap: float = 0.1,
+        under_load: bool = False,
+    ) -> None:
+       
+        self.can_iface = can_iface
+        self.monitor_manager = monitor_manager
+        self.storage = storage
+        self.fusion = fusion or EvidenceFusion()
+        self.tx_log = tx_log
+        self.pre_window = pre_window
+        self.post_window = post_window
+        self.trial_gap = trial_gap
+        self.under_load = under_load
+
+        if under_load:
+            print("[WARN] under_load=True: 배경 트래픽 유지는 현재 미구현 (stub)")
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def run(
+        self,
+        candidate: CandidateSnapshot,
+        n: int = 5,
+        *,
+        timing_timeout: float = 5.0,
+        dbc_timeout: float = 5.0,
+        top_n: Optional[int] = None,
+        report_mode: str = "fixed",
+    ) -> Tuple[ResultFrame, FusionResult]:
+     
+        print(
+            f"[Reproducer] seed_id={candidate.id} | n={n} | "
+            f"arb_id={hex(candidate.arb_id)} | payload={candidate.payload.hex()}"
+        )
+
+        frames = self._restore_frames(candidate)
+        print(f"[Reproducer] replay 프레임 수: {len(frames)}")
+
+        trial_results: List[Dict[str, Any]] = []
+        for i in range(n):
+            print(f"[Reproducer] -- trial {i + 1}/{n} --")
+
+            # replay -> monitor 수집
+            self.can_iface.replay(frames)
+            result = self.monitor_manager.collect_results(
+                timing_timeout=timing_timeout,
+                dbc_timeout=dbc_timeout,
+            )
+            trial_results.append(result)
+
+            if i < n - 1:
+                time.sleep(self.trial_gap)
+
+        # 7단계: ResultFrame 생성 + verdict 판정
+        frame = ResultFrame.from_trial_results(candidate.id, trial_results, top_n=top_n)
+        fusion_result = self.fusion.evaluate(frame)
+
+        print(
+            f"[Reproducer] verdict={fusion_result.verdict} | "
+            f"repro_rate={fusion_result.repro_rate:.2f} | "
+            f"fusion_score={fusion_result.fusion_score:.4f}"
+        )
+
+        # 8단계: candidate 업데이트 후 storage 저장
+        candidate.repro_verdict = fusion_result.verdict
+        candidate.repro_rate = fusion_result.repro_rate
+        candidate.repro_json = frame.to_dict()
+        candidate.last_evidence = fusion_result.detail
+
+        self.storage.save_candidate(candidate.id, candidate)
+        self.storage.save_report(candidate.id, frame.to_dict(), mode=report_mode)
+
+        return frame, fusion_result
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _restore_frames(self, candidate: CandidateSnapshot) -> List[Tuple[int, bytes]]:
+        
+        if self.tx_log is not None and candidate.last_send_idx is not None:
+            try:
+                frames = self.tx_log.get_frame_window(
+                    candidate.last_send_idx,
+                    pre=self.pre_window,
+                    post=self.post_window,
+                )
+                if frames:
+                    print(
+                        f"[Reproducer] tx_log 윈도우: center={candidate.last_send_idx} "
+                        f"pre={self.pre_window} post={self.post_window} -> {len(frames)} frames"
+                    )
+                    return frames
+                print("[Reproducer] tx_log 윈도우가 비어 있음 -> fallback")
+            except Exception as e:
+                print(f"[Reproducer] tx_log 오류 -> fallback ({e})")
+
+        print("[Reproducer] fallback: 단일 프레임 (arb_id, payload)")
+        return [(candidate.arb_id, candidate.payload)]


### PR DESCRIPTION
## 📌 PR 개요
- 재현(Reproduction) 파이프라인의 핵심 모듈들을 구현했습니다.
- `CandidateSnapshot`을 기반으로 n회 재현 실행 → 결과 집계 → 최종 verdict 판정까지의 흐름을 담당하는 `repro` 패키지를 추가했습니다.

## 🔍 주요 변경 사항
- `src/repro/__init__.py` 추가 (패키지 선언)
- `src/repro/report.py` 추가
  - `MonitorSummary`: monitor별 trial 집계 결과 (`fail_bitmap`, `scores`, `mean_score`)
  - `ResultFrame`: 재현 1세션 전체 결과 (`trials`, `reproduced`, `reproduction_rate`)
  - `from_trial_results()`: per-trial 결과 리스트 → `ResultFrame` 변환 로직
- `src/repro/evidence_fusion.py` 추가
  - `FusionResult`: 최종 판정 결과 (`verdict`, `fusion_score`, `repro_rate`, `detail`)
  - `EvidenceFusion`: `ResultFrame` → `PASS` / `SOFT_FAIL` / `HARD_FAIL` 판정
  - `binary` mode: `fusion_score = repro_rate`, threshold 비교
  - `weight` mode: monitor별 가중치 적용 후 `fusion_score` 계산
- `src/repro/reproducer.py` 추가
  - `TxLog` Protocol: `MessageLog` 연동을 위한 최소 인터페이스 정의
  - `Reproducer.run()`: n회 재현 실행 → `ResultFrame` + `FusionResult` 반환 및 storage 저장
  - `_restore_frames()`: `tx_log` window 복원 (기본) / 단일 프레임 fallback 처리

## ✅ 체크리스트

## ⚠️ 기타 참고 사항
- `EvidenceFusion` 기본값은 `mode="binary"`, `soft_threshold=0.3`, `hard_threshold=0.7`이며 생성자 파라미터로 변경 가능합니다.
- 각 모니터 결과 fusion은 reproduction 평균치이며 가중치를 변경할  수 있습니다.