### PR TITLE
Feature/merge candidate: candidate 로직 병합

### DIFF
--- a/src/monitor/monitor_manager.py
+++ b/src/monitor/monitor_manager.py
@@ -1,5 +1,5 @@
 import threading
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 from .timing_monitor import TimingMonitor
 from .uds_monitor import UDSMonitor
 from .dbc_monitor import DBCMonitor
@@ -242,6 +242,20 @@ class MonitorManager:
     def get_scores(self) -> Dict[str, float]:
         with self.state_lock:
             return self.scores.copy()
+
+    def collect_results(
+        self,
+        timing_timeout: Optional[float] = 5.0,
+        dbc_timeout: Optional[float] = 5.0,
+    ) -> Dict[str, Any]:
+        timeout = max(timing_timeout or 0.0, dbc_timeout or 0.0)
+        self.wait_for_completion(timeout=timeout)
+        scores = self.get_scores()
+        status = self.get_status()
+        return {
+            name: {"score": scores[name], "status": status[name]}
+            for name in ("timing", "uds", "dbc")
+        }
 
     def is_running(self) -> bool:
         return self.running

--- a/src/repro/candidate.py
+++ b/src/repro/candidate.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+class CandidateParseError(ValueError):
+    pass
+
+def parse_can_id(v: Any) -> int:
+    if isinstance(v, int):
+        return v
+    if isinstance(v, str):
+        s = v.strip().lower()
+        if s.startswith("0x"):
+            return int(s, 16)
+        try:
+            return int(s)
+        except ValueError as e:
+            raise CandidateParseError(f"Invalid CAN ID string: {v}") from e
+    raise CandidateParseError(f"Invalid type for arb_id: {type(v)}")
+
+def parse_payload(s: Any) -> bytes:
+    if not isinstance(s, str):
+        raise CandidateParseError("payload must be hex string")
+    v = s.strip().lower().replace(" ", "").replace(":", "").replace("-", "")
+    if v.startswith("0x"):
+        v = v[2:]
+    if not v:
+        raise CandidateParseError("payload hex string is empty")
+    try:
+        return bytes.fromhex(v)
+    except ValueError as e:
+        raise CandidateParseError(f"Invalid payload hex string: {s}") from e
+
+def sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+@dataclass
+class CandidateSnapshot:
+    arb_id: int
+    payload: bytes
+    dlc: int
+    id: int
+    priority: Optional[int] = None
+    parent_id: Optional[int] = None
+    root_id: Optional[int] = None
+    depth: Optional[int] = None
+    monitor_json: Optional[Dict[str, Any]] = None
+    repro_verdict: Optional[str] = None
+    repro_rate: Optional[float] = None
+    last_evidence: Optional[Any] = None
+    repro_json: Optional[Dict[str, Any]] = None
+    last_send_idx: Optional[int] = None
+    fingerprint: Optional[str] = None
+
+    @staticmethod
+    def from_dict(d: Dict[str, Any]) -> "CandidateSnapshot":
+        if not isinstance(d, dict):
+            raise CandidateParseError("Candidate JSON root must be an object(dict)")
+
+        cid = d.get("id")
+        if cid is None:
+            raise CandidateParseError("Missing required field: id")
+
+        arb_id = parse_can_id(d.get("arb_id"))
+        payload = parse_payload(d.get("payload"))
+        dlc = d.get("dlc", len(payload))
+        last_send_idx = d.get("last_send_idx")
+        priority = d.get("priority")
+        depth = d.get("depth")
+        parent_id = d.get("parent_id")
+        root_id = d.get("root_id")
+        monitor_json = d.get("monitor_json")
+        repro_verdict = d.get("repro_verdict")
+        repro_rate = d.get("repro_rate")
+        last_evidence = d.get("last_evidence")
+        repro_json = d.get("repro_json")
+
+        # fingerprint
+        fp = d.get("fingerprint")
+        if fp is None:
+            fp = sha256_hex(payload)
+        else:
+            fp = str(fp).strip().lower()
+
+        return CandidateSnapshot(
+            arb_id=arb_id,
+            payload=payload,
+            dlc=dlc,
+            id=cid,
+            priority=priority,
+            parent_id=parent_id,
+            root_id=root_id,
+            depth=depth,
+            monitor_json=monitor_json,
+            repro_verdict=str(repro_verdict) if repro_verdict is not None else None,
+            repro_rate=float(repro_rate) if repro_rate is not None else None,
+            last_evidence=last_evidence,
+            repro_json=repro_json,
+            last_send_idx=last_send_idx,
+            fingerprint=fp,
+        )
+
+    @staticmethod
+    def from_seed(seed: Any) -> "CandidateSnapshot":
+        monitor_json: Optional[Dict[str, Any]] = None
+        if hasattr(seed, "meta") and seed.meta:
+            monitor_json = seed.meta.get("monitor_result")
+        fp = getattr(seed, "fingerprint", None)
+        if fp is None and getattr(seed, "payload", None):
+            fp = sha256_hex(bytes(seed.payload))
+        return CandidateSnapshot(
+            id=seed.id,
+            arb_id=seed.arb_id,
+            payload=bytes(seed.payload) if seed.payload else b"",
+            dlc=seed.dlc if seed.dlc is not None else 8,
+            priority=getattr(seed, "priority", None),
+            parent_id=getattr(seed, "parent_id", None),
+            root_id=getattr(seed, "root_id", None),
+            depth=getattr(seed, "depth", None),
+            last_send_idx=getattr(seed, "last_send_idx", None),
+            monitor_json=monitor_json,
+            repro_verdict=getattr(seed, "repro_verdict", None),
+            repro_rate=getattr(seed, "repro_rate", None),
+            last_evidence=getattr(seed, "last_evidence", None),
+            repro_json=getattr(seed, "repro_json", None),
+            fingerprint=fp,
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        fp = self.fingerprint or sha256_hex(self.payload)
+
+        return {
+            "id": self.id,
+            "arb_id": self.arb_id,
+            "payload": self.payload.hex(),
+            "dlc": self.dlc,
+            "priority": self.priority,
+            "parent_id": self.parent_id,
+            "root_id": self.root_id,
+            "depth": self.depth,
+            "monitor_json": self.monitor_json,
+            "repro_verdict": self.repro_verdict,
+            "repro_rate": self.repro_rate,
+            "last_evidence": self.last_evidence,
+            "repro_json": self.repro_json,
+            "last_send_idx": self.last_send_idx,
+            "fingerprint": fp,
+        }

--- a/src/repro/evidence_fusion.py
+++ b/src/repro/evidence_fusion.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+from .report import ResultFrame, MONITOR_NAMES
+
+PASS      = "PASS"
+SOFT_FAIL = "SOFT_FAIL"
+HARD_FAIL = "HARD_FAIL"
+
+_DEFAULT_SOFT = 0.3
+_DEFAULT_HARD = 0.7
+
+_DEFAULT_WEIGHTS: Dict[str, float] = {
+    "timing": 0.3,
+    "uds":    0.4,
+    "dbc":    0.3,
+}
+
+
+@dataclass
+class FusionResult:
+    verdict: str            # PASS / SOFT_FAIL / HARD_FAIL
+    fusion_score: float     # 0.0 ~ 1.0
+    repro_rate: float
+    detail: Dict[str, float]  # monitor별 기여도
+
+
+class EvidenceFusion:
+    """
+    ResultFrame -> verdict + fusion_score 계산.
+
+    mode='binary':
+        fusion_score = repro_rate
+        threshold 비교로 verdict 결정
+
+    mode='weight':
+        fusion_score = sum((w_i / sum_w) * mean_score_i)
+        threshold 비교로 verdict 결정
+    """
+
+    def __init__(
+        self,
+        mode: str = "binary",
+        soft_threshold: float = _DEFAULT_SOFT,
+        hard_threshold: float = _DEFAULT_HARD,
+        weights: Optional[Dict[str, float]] = None,
+    ) -> None:
+        if mode not in ("binary", "weight"):
+            raise ValueError(f"mode는 'binary' 또는 'weight' 중 하나여야 합니다. got={mode!r}")
+        if soft_threshold >= hard_threshold:
+            raise ValueError(
+                f"soft_threshold({soft_threshold}) < hard_threshold({hard_threshold}) 이어야 합니다."
+            )
+        self.mode = mode
+        self.soft_threshold = soft_threshold
+        self.hard_threshold = hard_threshold
+        self.weights = weights or dict(_DEFAULT_WEIGHTS)
+
+    # ------------------------------------------------------------------
+
+    def evaluate(self, frame: ResultFrame) -> FusionResult:
+        if self.mode == "binary":
+            return self._binary(frame)
+        return self._weighted(frame)
+
+    # ------------------------------------------------------------------
+
+    def _verdict(self, score: float) -> str:
+        if score >= self.hard_threshold:
+            return HARD_FAIL
+        if score >= self.soft_threshold:
+            return SOFT_FAIL
+        return PASS
+
+    def _mean(self, frame: ResultFrame, name: str) -> float:
+        """MonitorSummary 인스턴스 또는 dict 모두 처리"""
+        s = frame.monitor_summary.get(name)
+        if s is None:
+            return 0.0
+        return s.mean_score if hasattr(s, "mean_score") else float(s.get("mean_score", 0.0))
+
+    def _binary(self, frame: ResultFrame) -> FusionResult:
+        rr = frame.reproduction_rate
+        detail = {name: self._mean(frame, name) for name in MONITOR_NAMES}
+        return FusionResult(
+            verdict=self._verdict(rr),
+            fusion_score=round(rr, 4),
+            repro_rate=rr,
+            detail=detail,
+        )
+
+    def _weighted(self, frame: ResultFrame) -> FusionResult:
+        total_w = sum(self.weights.get(m, 0.0) for m in MONITOR_NAMES)
+        if total_w <= 0:
+            raise ValueError("weights 합이 0 이하입니다.")
+
+        detail: Dict[str, float] = {}
+        score = 0.0
+        for name in MONITOR_NAMES:
+            w = self.weights.get(name, 0.0)
+            contrib = (w / total_w) * self._mean(frame, name)
+            detail[name] = round(contrib, 4)
+            score += contrib
+
+        score = round(min(score, 1.0), 4)
+        return FusionResult(
+            verdict=self._verdict(score),
+            fusion_score=score,
+            repro_rate=frame.reproduction_rate,
+            detail=detail,
+        )

--- a/src/repro/report.py
+++ b/src/repro/report.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from typing import Any, Dict, List, Optional
+
+# 파이프라인 전체에서 monitor 이름 순서 통일
+MONITOR_NAMES: tuple[str, ...] = ("timing", "uds", "dbc")
+
+_FAIL_STATUSES = frozenset({"crashed", "timeout"})
+
+
+@dataclass
+class MonitorSummary:
+    name: str
+    fail_count: int         # 몇 번의 trial에서 fail 판정
+    fail_bitmap: List[int]  # 길이 n, trial별 1(fail) / 0(pass)
+    scores: List[float]     # trial별 원시 score
+    mean_score: float       # 평균 score
+
+
+@dataclass
+class ResultFrame:
+    seed_id: int
+    trials: int                             # n
+    reproduced: int                         # k: 하나 이상의 monitor가 fail한 trial 수
+    reproduction_rate: float                # k / n
+    monitor_summary: Dict[str, MonitorSummary]
+    trial_results: List[Dict[str, Any]]     # per-trial raw (top_n 적용 후)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "seed_id": self.seed_id,
+            "trials": self.trials,
+            "reproduced": self.reproduced,
+            "reproduction_rate": self.reproduction_rate,
+            "monitor_summary": {
+                name: asdict(s) if isinstance(s, MonitorSummary) else dict(s)
+                for name, s in self.monitor_summary.items()
+            },
+            "trial_results": self.trial_results,
+        }
+
+    @staticmethod
+    def from_trial_results(
+        seed_id: int,
+        trial_results: List[Dict[str, Any]],
+        *,
+        top_n: Optional[int] = None,
+    ) -> "ResultFrame":
+        
+        n = len(trial_results)
+        if n == 0:
+            return ResultFrame(
+                seed_id=seed_id, trials=0, reproduced=0,
+                reproduction_rate=0.0, monitor_summary={}, trial_results=[],
+            )
+
+        summaries: Dict[str, MonitorSummary] = {}
+        for name in MONITOR_NAMES:
+            scores: List[float] = []
+            bitmap: List[int] = []
+
+            for tr in trial_results:
+                mv = tr.get(name, {})
+                score = float(mv.get("score", 0.0))
+                status = str(mv.get("status", "ok"))
+                scores.append(score)
+                bitmap.append(1 if (score > 0.0 or status in _FAIL_STATUSES) else 0)
+
+            summaries[name] = MonitorSummary(
+                name=name,
+                fail_count=sum(bitmap),
+                fail_bitmap=bitmap,
+                scores=scores,
+                mean_score=round(sum(scores) / n, 4),
+            )
+
+        # 하나 이상의 monitor가 fail한 trial 수 (k)
+        reproduced = sum(
+            1 for i in range(n)
+            if any(summaries[m].fail_bitmap[i] for m in MONITOR_NAMES)
+        )
+
+        return ResultFrame(
+            seed_id=seed_id,
+            trials=n,
+            reproduced=reproduced,
+            reproduction_rate=round(reproduced / n, 4),
+            monitor_summary=summaries,
+            trial_results=trial_results if top_n is None else trial_results[:top_n],
+        )

--- a/src/repro/reproducer.py
+++ b/src/repro/reproducer.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, List, Optional, Protocol, Tuple, runtime_checkable
+
+from .candidate import CandidateSnapshot
+from .evidence_fusion import EvidenceFusion, FusionResult
+from .report import ResultFrame
+from .storage import ReproStorage
+
+
+@runtime_checkable
+class TxLog(Protocol):
+
+    def get_frame_window(
+        self,
+        center_idx: int,
+        pre: int,
+        post: int,
+    ) -> List[Tuple[int, bytes]]: ...
+
+
+class Reproducer:
+
+
+    def __init__(
+        self,
+        can_iface,
+        monitor_manager,
+        storage: ReproStorage,
+        fusion: Optional[EvidenceFusion] = None,
+        *,
+        tx_log: Optional[TxLog] = None,
+        pre_window: int = 5,
+        post_window: int = 2,
+        trial_gap: float = 0.1,
+        under_load: bool = False,
+    ) -> None:
+       
+        self.can_iface = can_iface
+        self.monitor_manager = monitor_manager
+        self.storage = storage
+        self.fusion = fusion or EvidenceFusion()
+        self.tx_log = tx_log
+        self.pre_window = pre_window
+        self.post_window = post_window
+        self.trial_gap = trial_gap
+        self.under_load = under_load
+
+        if under_load:
+            print("[WARN] under_load=True: 배경 트래픽 유지는 현재 미구현 (stub)")
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def run(
+        self,
+        candidate: CandidateSnapshot,
+        n: int = 5,
+        *,
+        timing_timeout: float = 5.0,
+        dbc_timeout: float = 5.0,
+        top_n: Optional[int] = None,
+        report_mode: str = "fixed",
+    ) -> Tuple[ResultFrame, FusionResult]:
+     
+        print(
+            f"[Reproducer] seed_id={candidate.id} | n={n} | "
+            f"arb_id={hex(candidate.arb_id)} | payload={candidate.payload.hex()}"
+        )
+
+        frames = self._restore_frames(candidate)
+        print(f"[Reproducer] replay 프레임 수: {len(frames)}")
+
+        trial_results: List[Dict[str, Any]] = []
+        for i in range(n):
+            print(f"[Reproducer] -- trial {i + 1}/{n} --")
+
+            # replay -> monitor 수집
+            self.can_iface.replay(frames)
+            result = self.monitor_manager.collect_results(
+                timing_timeout=timing_timeout,
+                dbc_timeout=dbc_timeout,
+            )
+            trial_results.append(result)
+
+            if i < n - 1:
+                time.sleep(self.trial_gap)
+
+        # 7단계: ResultFrame 생성 + verdict 판정
+        frame = ResultFrame.from_trial_results(candidate.id, trial_results, top_n=top_n)
+        fusion_result = self.fusion.evaluate(frame)
+
+        print(
+            f"[Reproducer] verdict={fusion_result.verdict} | "
+            f"repro_rate={fusion_result.repro_rate:.2f} | "
+            f"fusion_score={fusion_result.fusion_score:.4f}"
+        )
+
+        # 8단계: candidate 업데이트 후 storage 저장
+        candidate.repro_verdict = fusion_result.verdict
+        candidate.repro_rate = fusion_result.repro_rate
+        candidate.repro_json = frame.to_dict()
+        candidate.last_evidence = fusion_result.detail
+
+        self.storage.save_candidate(candidate.id, candidate)
+        self.storage.save_report(candidate.id, frame.to_dict(), mode=report_mode)
+
+        return frame, fusion_result
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _restore_frames(self, candidate: CandidateSnapshot) -> List[Tuple[int, bytes]]:
+        
+        if self.tx_log is not None and candidate.last_send_idx is not None:
+            try:
+                frames = self.tx_log.get_frame_window(
+                    candidate.last_send_idx,
+                    pre=self.pre_window,
+                    post=self.post_window,
+                )
+                if frames:
+                    print(
+                        f"[Reproducer] tx_log 윈도우: center={candidate.last_send_idx} "
+                        f"pre={self.pre_window} post={self.post_window} -> {len(frames)} frames"
+                    )
+                    return frames
+                print("[Reproducer] tx_log 윈도우가 비어 있음 -> fallback")
+            except Exception as e:
+                print(f"[Reproducer] tx_log 오류 -> fallback ({e})")
+
+        print("[Reproducer] fallback: 단일 프레임 (arb_id, payload)")
+        return [(candidate.arb_id, candidate.payload)]

--- a/src/repro/reproducer.py
+++ b/src/repro/reproducer.py
@@ -12,12 +12,12 @@ from .storage import ReproStorage
 @runtime_checkable
 class TxLog(Protocol):
 
-    def get_frame_window(
+    def get_window(
         self,
-        center_idx: int,
+        anchor_send_idx: int,
         pre: int,
         post: int,
-    ) -> List[Tuple[int, bytes]]: ...
+    ) -> List[Any]: ...
 
 
 class Reproducer:
@@ -78,7 +78,8 @@ class Reproducer:
             print(f"[Reproducer] -- trial {i + 1}/{n} --")
 
             # replay -> monitor 수집
-            self.can_iface.replay(frames)
+            for arb_id, payload in frames:
+                self.can_iface.send_raw(payload, arb_id=arb_id)
             result = self.monitor_manager.collect_results(
                 timing_timeout=timing_timeout,
                 dbc_timeout=dbc_timeout,
@@ -117,12 +118,16 @@ class Reproducer:
         
         if self.tx_log is not None and candidate.last_send_idx is not None:
             try:
-                frames = self.tx_log.get_frame_window(
+                raw = self.tx_log.get_window(
                     candidate.last_send_idx,
                     pre=self.pre_window,
                     post=self.post_window,
                 )
-                if frames:
+                if raw:
+                    frames = [
+                        (f.arb_id, f.payload) if hasattr(f, "arb_id") else f
+                        for f in raw
+                    ]
                     print(
                         f"[Reproducer] tx_log 윈도우: center={candidate.last_send_idx} "
                         f"pre={self.pre_window} post={self.post_window} -> {len(frames)} frames"

--- a/src/repro/storage.py
+++ b/src/repro/storage.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, is_dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional, Union
+
+from .candidate import CandidateSnapshot
+
+JsonDict = Dict[str, Any]
+
+class StorageIOError(RuntimeError):
+    pass
+
+class ReproStorage:
+    def __init__(self, artifacts_root: Union[str, Path] = "artifacts") -> None:
+        self.root = Path(artifacts_root)
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    def _sid(self, seed_id: Union[str, int]) -> str:
+        s = str(seed_id).strip()
+        if not s:
+            raise ValueError("seed_id must be non-empty")
+        return s
+
+    def artifact_dir(self, seed_id: Union[str, int]) -> Path:
+        p = self.root / "repro" / self._sid(seed_id)
+        p.mkdir(parents=True, exist_ok=True)
+        return p
+
+    def candidate_path(self, seed_id: Union[str, int]) -> Path:
+        return self.artifact_dir(seed_id) / "candidate.json"
+
+    def report_path(self, seed_id: Union[str, int], name: str) -> Path:
+        return self.artifact_dir(seed_id) / name
+
+    def _dump_json(self, path: Path, obj: Any) -> None:
+        try:
+            if is_dataclass(obj):
+                obj = asdict(obj)
+            text = json.dumps(obj, ensure_ascii=False, indent=2)
+        except Exception:
+            text = json.dumps({"_raw": str(obj)}, ensure_ascii=False, indent=2)
+
+        try:
+            path.write_text(text, encoding="utf-8")
+        except Exception as e:
+            raise StorageIOError(f"Failed to write: {path}") from e
+
+    def _load_json(self, path: Path) -> Any:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except Exception as e:
+            raise StorageIOError(f"Failed to read: {path}") from e
+
+        try:
+            return json.loads(text)
+        except Exception as e:
+            raise StorageIOError(f"Invalid JSON: {path}") from e
+
+    def save_candidate(self, seed_id: Union[str, int], c: CandidateSnapshot) -> Path:
+        p = self.candidate_path(seed_id)
+        self._dump_json(p, c.to_dict())
+        return p
+
+    def load_candidate(self, seed_id: Union[str, int]) -> CandidateSnapshot:
+        p = self.candidate_path(seed_id)
+        d = self._load_json(p)
+        if not isinstance(d, dict):
+            raise StorageIOError(f"candidate.json must be a JSON object: {p}")
+        return CandidateSnapshot.from_dict(d)
+
+    def _report_name(self, seed_id: Union[str, int]) -> str:
+        d = self.artifact_dir(seed_id)
+        n = 1
+
+        for f in d.glob("report_*.json"):
+            stem = f.stem
+            try:
+                suffix = stem.split("_", 1)[1]
+                if suffix.isdigit():
+                    n = max(n, int(suffix) + 1)
+            except (IndexError, ValueError):
+                pass
+
+        return f"report_{n:03d}.json"
+
+    def save_report(
+        self,
+        seed_id: Union[str, int],
+        report: Any,
+        *,
+        name: Optional[str] = None,
+    ) -> Path:
+        fname = name or self._report_name(seed_id)
+        p = self.report_path(seed_id, fname)
+        self._dump_json(p, report)
+        return p
+
+    def load_report(self, seed_id: Union[str, int], name: str) -> JsonDict:
+        p = self.report_path(seed_id, name)
+        d = self._load_json(p)
+        if not isinstance(d, dict):
+            raise StorageIOError(f"report must be a JSON object: {p}")
+        return d
+
+    def latest_report(self, seed_id: Union[str, int]) -> Optional[Path]:
+        d = self.artifact_dir(seed_id)
+        latest: Optional[Path] = None
+        max_n = 0
+
+        for f in d.glob("report_*.json"):
+            stem = f.stem
+            try:
+                suffix = stem.split("_", 1)[1]
+                if suffix.isdigit():
+                    n = int(suffix)
+                    if n > max_n:
+                        max_n = n
+                        latest = f
+            except (IndexError, ValueError):
+                pass
+
+        return latest

--- a/src/seeds/factory.py
+++ b/src/seeds/factory.py
@@ -1,0 +1,97 @@
+# src/seeds/factory.py
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from .seed_manager import Seed
+
+MAX_CAN_DLC = 8
+
+
+def _clamp_dlc(dlc: int) -> int:
+    if dlc < 0:
+        return 0
+    return min(dlc, MAX_CAN_DLC)
+
+
+def build_initial_seeds_from_parsed_dbc(
+    parsed_dbc: Dict[str, Any],
+    *,
+    default_priority: int = 0,
+) -> List[Seed]:
+    """
+    DbcParser.parse() 결과(dict)를 받아 초기 후보(Seed) 리스트를 생성.
+    - 메시지(frame) 단위로 1개씩 생성
+    - payload는 기본으로 dlc 길이만큼 0x00
+    """
+    out: List[Seed] = []
+
+    for msg in parsed_dbc.get("messages", []):
+        arb_id = int(msg["id"])
+        dlc = _clamp_dlc(int(msg.get("dlc", 8)))
+        is_ext = bool(msg.get("is_extended_frame", False))
+
+        payload = bytes([0x00] * dlc)
+
+        meta = {
+            "msg_name": msg.get("name"),
+            "dlc": dlc,
+            "is_extended": is_ext,
+            "comment": msg.get("comment"),
+            "cycle_time": msg.get("cycle_time"),
+        }
+
+        out.append(
+            Seed(
+                arb_id=arb_id,
+                payload=payload,
+                dlc=dlc,
+                is_extended=is_ext,
+                parent_id=None,
+                root_id=None,
+                depth=0,
+                priority=default_priority,
+                status="queued",
+                meta=meta,
+            )
+        )
+
+    return out
+
+
+def build_child_seed(
+    parent: Seed,
+    *,
+    payload: bytes,
+    priority_delta: int = 0,
+    status: str = "queued",
+    extra_meta: Optional[Dict[str, Any]] = None,
+) -> Seed:
+    """
+    parent Seed로부터 child Seed 생성 규칙.
+    - parent_id/depth/root_id/priority/meta를 자동 구성
+    """
+    assert parent.id is not None, "build_child_seed: parent.id is None (parent must be loaded from DB)"
+
+    dlc = _clamp_dlc(parent.dlc if parent.dlc is not None else len(payload))
+    child_payload = payload[:dlc]
+
+    pr = int(parent.priority) + int(priority_delta)
+
+    meta = dict(parent.meta or {})
+    meta.update({"parent": parent.id, "depth": parent.depth + 1})
+    if extra_meta:
+        meta.update(extra_meta)
+
+    return Seed(
+        arb_id=parent.arb_id,
+        payload=child_payload,
+        dlc=dlc,
+        is_extended=parent.is_extended,
+        parent_id=parent.id,
+        root_id=parent.root_id,
+        depth=parent.depth + 1,
+        priority=pr,
+        status=status,
+        meta=meta,
+    )

--- a/src/seeds/mutation_engine.py
+++ b/src/seeds/mutation_engine.py
@@ -1,0 +1,47 @@
+# src/seeds/mutation_engine.py
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from .seed_manager import Seed, SeedManager
+from .factory import build_child_seed
+from ..mutation.mutator import Mutator
+
+class MutationEngine:
+    """
+    parent Seed -> mutated payloads -> child Seed insert -> new child ids 반환
+    """
+
+    def __init__(self, seed_manager: SeedManager):
+        self.sm = seed_manager
+
+    def mutate_and_store_children(
+        self,
+        parent: Seed,
+        *,
+        weights: Optional[Dict[str, float]] = None,
+        min_length: int = 1,
+        priority_delta: int = 0,
+        extra_meta: Optional[dict] = None,
+    ) -> List[int]:
+        weights = weights or {}
+
+        base_payload = bytes(parent.payload or b"")[: int(parent.dlc)]
+        mut = Mutator(data=base_payload, weights=weights, min_length=min_length)
+        mutated_payloads = mut.mutate_manager()
+
+        new_ids: List[int] = []
+        for p in mutated_payloads:
+            child = build_child_seed(
+                parent,
+                payload=p,
+                priority_delta=priority_delta,
+                status="queued",
+                extra_meta=extra_meta,
+            )
+
+            new_id = self.sm.insert_seed(child)  # dedup이면 None
+            if new_id is not None:
+                new_ids.append(int(new_id))
+
+        return new_ids

--- a/src/seeds/pipeline_candidate.py
+++ b/src/seeds/pipeline_candidate.py
@@ -1,0 +1,69 @@
+# src/seeds/pipeline_candidate.py
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+from .seed_manager import SeedManager
+from .seed_queue import SeedQueue
+from .tx_log import TxLog, TxFrame
+
+
+class CandidatePipeline:
+    def __init__(
+        self,
+        *,
+        cfg: Dict,
+        can_iface: object,
+        seed_manager: SeedManager,
+        seed_queue: SeedQueue,
+        tx_log: TxLog,
+    ):
+        self.cfg = cfg
+        self.can = can_iface
+        self.sm = seed_manager
+        self.q = seed_queue
+        self.txlog = tx_log
+        self.running = False
+
+    def send_one(self) -> Optional[int]:
+        """
+        큐에서 seed 하나를 꺼내 전송하고 seed_id 반환.
+        전송할 seed가 없거나 실패하면 None 반환.
+        """
+        can_cfg = self.cfg.get("can", {})
+        force_default_id = bool(can_cfg.get("force_default_id", True))
+        default_id = int(can_cfg.get("default_id", "0x6A6"), 16)
+
+        seed_id = self.q.pop()
+        if seed_id is None:
+            return None
+
+        seed = self.sm.get_seed(seed_id)
+        if seed is None:
+            self.sm.update_status(seed_id, "error")
+            return None
+
+        arb_id = default_id if force_default_id else int(seed.arb_id)
+        payload = bytes(seed.payload or b"")[: int(seed.dlc)]
+        dlc = int(seed.dlc)
+        is_ext = bool(seed.is_extended)
+
+        frame = TxFrame(arb_id=arb_id, payload=payload, dlc=dlc)
+
+        try:
+            self.can.send_raw(frame.payload, arb_id=frame.arb_id, is_extended=is_ext)
+        except Exception:
+            self.sm.update_status(seed_id, "error")
+            return None
+
+        try:
+            send_idx = self.txlog.append(frame, seed_id=seed_id)
+            self.sm.set_last_send_idx(seed_id, send_idx)
+        except Exception:
+            pass
+
+        self.sm.update_status(seed_id, "sent")
+        return seed_id
+
+    def stop(self) -> None:
+        self.running = False

--- a/src/seeds/seed_manager.py
+++ b/src/seeds/seed_manager.py
@@ -1,18 +1,23 @@
-# src/seeds/seed_manager.py
+from __future__ import annotations
+
 import json
 import sqlite3
+import hashlib
 from dataclasses import dataclass, field
-from typing import Any, List, Optional, Dict
+from typing import Any, Dict, List, Optional
+
+
+def _sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
 
 
 @dataclass
 class SignalMeta:
-    """Signal 관련 세부 메타데이터 구조"""
     start_bit: Optional[int] = None
     length: Optional[int] = None
     byte_order: Optional[str] = None
     is_signed: Optional[bool] = None
-    factor: Optional[float] = None      # scale → factor로 변경
+    factor: Optional[float] = None
     offset: Optional[float] = None
     minimum: Optional[float] = None
     maximum: Optional[float] = None
@@ -22,80 +27,341 @@ class SignalMeta:
 
 @dataclass
 class Seed:
-    """단일 Signal을 나타내는 Seed"""
-    message_id: int
-    signal_name: str
+    message_id: Optional[int] = None
+    signal_name: str = ""
     desc: str = ""
     priority: int = 1
     metadata: SignalMeta = field(default_factory=SignalMeta)
     id: Optional[int] = None
 
+    arb_id: Optional[int] = None
+    payload: bytes = b""
+    dlc: int = 8
+    is_extended: bool = False
+
+    parent_id: Optional[int] = None
+    root_id: Optional[int] = None
+    depth: int = 0
+    status: str = "queued"
+    meta: Dict[str, Any] = field(default_factory=dict)
+    last_send_idx: Optional[int] = None
+
+    repro_verdict: Optional[str] = None
+    repro_rate: Optional[float] = None
+    last_evidence: Optional[str] = None
+    repro_json: Optional[Dict[str, Any]] = None
+
+    fingerprint: Optional[str] = None
+
+    def ensure_candidate_defaults(self) -> None:
+        if self.arb_id is None and self.message_id is not None:
+            self.arb_id = int(self.message_id)
+        if self.message_id is None and self.arb_id is not None:
+            self.message_id = int(self.arb_id)
+        if self.dlc is None:
+            self.dlc = len(self.payload or b"")
+        if not self.payload:
+            self.payload = bytes([0x00] * int(self.dlc))
+        if self.fingerprint is None:
+            self.fingerprint = _sha256_hex(bytes(self.payload or b""))
+
 
 class SeedManager:
-    """Seed Pool 관리 및 DB 연동 클래스"""
-
     def __init__(self, db_path: str = "seeds.db"):
         self.conn = sqlite3.connect(db_path)
+        self.conn.row_factory = sqlite3.Row
         self._create_table()
+        self._migrate()
 
     def _create_table(self):
-        query = """
-        CREATE TABLE IF NOT EXISTS seeds (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            message_id INTEGER,
-            signal_name TEXT,
-            desc TEXT,
-            priority INTEGER,
-            metadata TEXT
-        );
-        """
-        self.conn.execute(query)
+        self.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS seeds (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+
+                message_id INTEGER,
+                signal_name TEXT,
+                desc TEXT,
+                priority INTEGER NOT NULL DEFAULT 1,
+                metadata TEXT,
+
+                arb_id INTEGER,
+                payload BLOB,
+                dlc INTEGER DEFAULT 8,
+                is_extended INTEGER NOT NULL DEFAULT 0,
+
+                parent_id INTEGER,
+                root_id INTEGER,
+                depth INTEGER NOT NULL DEFAULT 0,
+                status TEXT NOT NULL DEFAULT 'queued',
+                meta_json TEXT,
+
+                last_send_idx INTEGER,
+
+                repro_verdict TEXT,
+                repro_rate REAL,
+                last_evidence TEXT,
+                repro_json TEXT,
+
+                fingerprint TEXT,
+
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+            """
+        )
         self.conn.commit()
 
+    def _migrate(self):
+        self._ensure_column("seeds", "arb_id", "INTEGER")
+        self._ensure_column("seeds", "payload", "BLOB")
+        self._ensure_column("seeds", "dlc", "INTEGER DEFAULT 8")
+        self._ensure_column("seeds", "is_extended", "INTEGER NOT NULL DEFAULT 0")
+        self._ensure_column("seeds", "parent_id", "INTEGER")
+        self._ensure_column("seeds", "root_id", "INTEGER")
+        self._ensure_column("seeds", "depth", "INTEGER NOT NULL DEFAULT 0")
+        self._ensure_column("seeds", "status", "TEXT NOT NULL DEFAULT 'queued'")
+        self._ensure_column("seeds", "meta_json", "TEXT")
+        self._ensure_column("seeds", "last_send_idx", "INTEGER")
+        self._ensure_column("seeds", "repro_verdict", "TEXT")
+        self._ensure_column("seeds", "repro_rate", "REAL")
+        self._ensure_column("seeds", "last_evidence", "TEXT")
+        self._ensure_column("seeds", "repro_json", "TEXT")
+        self._ensure_column("seeds", "fingerprint", "TEXT")
+
+        self.conn.execute(
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS uq_seeds_candidate_dedup
+            ON seeds(arb_id, dlc, fingerprint);
+            """
+        )
+        self.conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_seeds_priority
+            ON seeds(priority DESC, id ASC);
+            """
+        )
+        self.conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_seeds_status_priority
+            ON seeds(status, priority DESC, id ASC);
+            """
+        )
+        self.conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_seeds_root
+            ON seeds(root_id);
+            """
+        )
+        self.conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_seeds_parent
+            ON seeds(parent_id);
+            """
+        )
+        self.conn.commit()
+
+    def _ensure_column(self, table: str, col: str, col_type: str):
+        rows = self.conn.execute(f"PRAGMA table_info({table});").fetchall()
+        existing_cols = {row["name"] for row in rows}
+        if col not in existing_cols:
+            self.conn.execute(f"ALTER TABLE {table} ADD COLUMN {col} {col_type};")
+            self.conn.commit()
+
     def add_seed(self, seed: Seed) -> int:
-        """새로운 Seed를 DB에 추가"""
-        query = """
-        INSERT INTO seeds (message_id, signal_name, desc, priority, metadata)
-        VALUES (?, ?, ?, ?, ?);
-        """
+        seed.ensure_candidate_defaults()
+
         cur = self.conn.execute(
-            query,
+            """
+            INSERT INTO seeds (
+                message_id, signal_name, desc, priority, metadata,
+                arb_id, payload, dlc, is_extended,
+                parent_id, root_id, depth, status, meta_json,
+                last_send_idx,
+                repro_verdict, repro_rate, last_evidence, repro_json,
+                fingerprint
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+            """,
             (
                 seed.message_id,
                 seed.signal_name,
                 seed.desc,
                 seed.priority,
-                json.dumps(seed.metadata.__dict__),
+                self._dump_signal_meta(seed.metadata),
+                seed.arb_id,
+                bytes(seed.payload or b""),
+                int(seed.dlc),
+                1 if seed.is_extended else 0,
+                seed.parent_id,
+                seed.root_id,
+                int(seed.depth),
+                seed.status,
+                json.dumps(seed.meta or {}, ensure_ascii=False),
+                seed.last_send_idx,
+                seed.repro_verdict,
+                seed.repro_rate,
+                seed.last_evidence,
+                json.dumps(seed.repro_json, ensure_ascii=False) if seed.repro_json is not None else None,
+                seed.fingerprint,
             ),
         )
         self.conn.commit()
-        return cur.lastrowid
+
+        new_id = int(cur.lastrowid)
+
+        if seed.root_id is None:
+            root_id = seed.parent_id if seed.parent_id is not None else new_id
+            if seed.parent_id is not None:
+                parent = self.get_seed(seed.parent_id)
+                if parent is not None and parent.root_id is not None:
+                    root_id = parent.root_id
+            self.conn.execute(
+                "UPDATE seeds SET root_id = ?, updated_at = datetime('now') WHERE id = ?",
+                (root_id, new_id),
+            )
+            self.conn.commit()
+
+        return new_id
+
+    def insert_seed(self, seed: Seed) -> Optional[int]:
+        seed.ensure_candidate_defaults()
+
+        cur = self.conn.execute(
+            """
+            INSERT OR IGNORE INTO seeds (
+                message_id, signal_name, desc, priority, metadata,
+                arb_id, payload, dlc, is_extended,
+                parent_id, root_id, depth, status, meta_json,
+                last_send_idx,
+                repro_verdict, repro_rate, last_evidence, repro_json,
+                fingerprint
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+            """,
+            (
+                seed.message_id,
+                seed.signal_name,
+                seed.desc,
+                seed.priority,
+                self._dump_signal_meta(seed.metadata),
+                seed.arb_id,
+                bytes(seed.payload or b""),
+                int(seed.dlc),
+                1 if seed.is_extended else 0,
+                seed.parent_id,
+                seed.root_id,
+                int(seed.depth),
+                seed.status,
+                json.dumps(seed.meta or {}, ensure_ascii=False),
+                seed.last_send_idx,
+                seed.repro_verdict,
+                seed.repro_rate,
+                seed.last_evidence,
+                json.dumps(seed.repro_json, ensure_ascii=False) if seed.repro_json is not None else None,
+                seed.fingerprint,
+            ),
+        )
+        self.conn.commit()
+
+        if cur.rowcount == 0:
+            return None
+
+        new_id = int(cur.lastrowid)
+
+        if seed.root_id is None:
+            root_id = seed.parent_id if seed.parent_id is not None else new_id
+            if seed.parent_id is not None:
+                parent = self.get_seed(seed.parent_id)
+                if parent is not None and parent.root_id is not None:
+                    root_id = parent.root_id
+            self.conn.execute(
+                "UPDATE seeds SET root_id = ?, updated_at = datetime('now') WHERE id = ?",
+                (root_id, new_id),
+            )
+            self.conn.commit()
+
+        return new_id
 
     def get_all(self) -> List[Seed]:
-        """DB에 등록된 모든 Seed 반환 (우선순위 기준 정렬)"""
         rows = self.conn.execute(
-            "SELECT id, message_id, signal_name, desc, priority, metadata FROM seeds ORDER BY priority DESC"
+            """
+            SELECT *
+            FROM seeds
+            ORDER BY priority DESC, id ASC
+            """
         ).fetchall()
+        return [self._row_to_seed(row) for row in rows]
 
-        seeds: List[Seed] = []
-        for row in rows:
-            meta_dict = json.loads(row[5]) if row[5] else {}
-            metadata = SignalMeta(**meta_dict)
-            seeds.append(
-                Seed(
-                    id=row[0],
-                    message_id=row[1],
-                    signal_name=row[2],
-                    desc=row[3],
-                    priority=row[4],
-                    metadata=metadata,
-                )
-            )
-        return seeds
+    def get_seed(self, seed_id: int) -> Optional[Seed]:
+        row = self.conn.execute(
+            "SELECT * FROM seeds WHERE id = ?",
+            (seed_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return self._row_to_seed(row)
 
     def update_priority(self, seed_id: int, new_priority: int):
         self.conn.execute(
-            "UPDATE seeds SET priority = ? WHERE id = ?", (new_priority, seed_id)
+            "UPDATE seeds SET priority = ?, updated_at = datetime('now') WHERE id = ?",
+            (new_priority, seed_id),
+        )
+        self.conn.commit()
+
+    def update_status(self, seed_id: int, new_status: str):
+        self.conn.execute(
+            "UPDATE seeds SET status = ?, updated_at = datetime('now') WHERE id = ?",
+            (new_status, seed_id),
+        )
+        self.conn.commit()
+
+    def set_last_send_idx(self, seed_id: int, send_idx: int):
+        self.conn.execute(
+            "UPDATE seeds SET last_send_idx = ?, updated_at = datetime('now') WHERE id = ?",
+            (send_idx, seed_id),
+        )
+        self.conn.commit()
+
+    def save_repro_summary(
+        self,
+        seed_id: int,
+        repro_verdict: str,
+        repro_rate: float,
+        last_evidence: Optional[str] = None,
+    ):
+        self.conn.execute(
+            """
+            UPDATE seeds
+            SET repro_verdict = ?, repro_rate = ?, last_evidence = ?, updated_at = datetime('now')
+            WHERE id = ?
+            """,
+            (repro_verdict, repro_rate, last_evidence, seed_id),
+        )
+        self.conn.commit()
+
+    def save_monitor_result(self, seed_id: int, monitor_result: Dict[str, Any]):
+        row = self.conn.execute(
+            "SELECT meta_json FROM seeds WHERE id = ?", (seed_id,)
+        ).fetchone()
+        if row is None:
+            return
+        current = json.loads(row["meta_json"]) if row["meta_json"] else {}
+        current["monitor_result"] = monitor_result
+        self.conn.execute(
+            "UPDATE seeds SET meta_json = ?, updated_at = datetime('now') WHERE id = ?",
+            (json.dumps(current, ensure_ascii=False), seed_id),
+        )
+        self.conn.commit()
+
+    def save_repro_report(self, seed_id: int, repro_report: Dict[str, Any]):
+        self.conn.execute(
+            """
+            UPDATE seeds
+            SET repro_json = ?, updated_at = datetime('now')
+            WHERE id = ?
+            """,
+            (json.dumps(repro_report, ensure_ascii=False), seed_id),
         )
         self.conn.commit()
 
@@ -106,10 +372,47 @@ class SeedManager:
     def close(self):
         self.conn.close()
 
-    # 메시지 단위 그룹 반환 (List[List[Seed]])
+    def _dump_signal_meta(self, metadata: Any) -> str:
+        if isinstance(metadata, SignalMeta):
+            return json.dumps(metadata.__dict__, ensure_ascii=False)
+        if isinstance(metadata, dict):
+            return json.dumps(metadata, ensure_ascii=False)
+        return json.dumps({}, ensure_ascii=False)
+
+    def _row_to_seed(self, row: sqlite3.Row) -> Seed:
+        metadata_raw = row["metadata"]
+        metadata_dict = json.loads(metadata_raw) if metadata_raw else {}
+        meta_json_raw = row["meta_json"]
+        meta_dict = json.loads(meta_json_raw) if meta_json_raw else {}
+        repro_json_raw = row["repro_json"]
+        repro_dict = json.loads(repro_json_raw) if repro_json_raw else None
+
+        return Seed(
+            id=row["id"],
+            message_id=row["message_id"],
+            signal_name=row["signal_name"] or "",
+            desc=row["desc"] or "",
+            priority=row["priority"],
+            metadata=SignalMeta(**metadata_dict),
+            arb_id=row["arb_id"],
+            payload=bytes(row["payload"]) if row["payload"] is not None else b"",
+            dlc=row["dlc"] if row["dlc"] is not None else 8,
+            is_extended=bool(row["is_extended"]) if row["is_extended"] is not None else False,
+            parent_id=row["parent_id"],
+            root_id=row["root_id"],
+            depth=row["depth"] if row["depth"] is not None else 0,
+            status=row["status"] or "queued",
+            meta=meta_dict,
+            last_send_idx=row["last_send_idx"],
+            repro_verdict=row["repro_verdict"],
+            repro_rate=row["repro_rate"],
+            last_evidence=row["last_evidence"],
+            repro_json=repro_dict,
+            fingerprint=row["fingerprint"],
+        )
+
     @staticmethod
     def from_dbc(parsed_dbc: Dict[str, Any]) -> List[List["Seed"]]:
-        """DbcParser.parse() 결과(dict)를 메시지 단위 Seed 그룹으로 변환"""
         grouped_seeds: List[List[Seed]] = []
 
         for msg in parsed_dbc.get("messages", []):
@@ -130,11 +433,22 @@ class SeedManager:
                 )
                 seed = Seed(
                     message_id=msg["id"],
+                    arb_id=msg["id"],
                     signal_name=sig["name"],
                     desc=f"Signal {sig['name']} in {msg['name']}",
                     priority=1,
                     metadata=meta,
+                    dlc=int(msg.get("dlc", 8)),
+                    is_extended=bool(msg.get("is_extended_frame", False)),
+                    payload=bytes([0x00] * int(msg.get("dlc", 8))),
+                    depth=0,
+                    status="queued",
+                    meta={
+                        "msg_name": msg.get("name"),
+                        "signal_name": sig.get("name"),
+                    },
                 )
+                seed.ensure_candidate_defaults()
                 message_group.append(seed)
 
             grouped_seeds.append(message_group)

--- a/src/seeds/seed_queue.py
+++ b/src/seeds/seed_queue.py
@@ -1,96 +1,83 @@
-# src/seeds/seed_queue.py
-
 import heapq
 import itertools
-from typing import List, Optional
-from ..seeds.seed_manager import Seed, SeedManager
+from typing import List, Optional, Union
+
+from .seed_manager import Seed, SeedManager
 
 
 class SeedQueue:
-    """
-    개선된 우선순위 기반 Seed 큐
-    - 우선순위(priority)가 같을 때 Seed 객체끼리 비교하는 문제 해결
-    - tiebreaker(counter) 사용하여 Heap 안정성 보장
-    """
-
     def __init__(self, db_path: str = "seeds.db"):
         self.manager = SeedManager(db_path)
-
-        # tiebreaker counter
         self._counter = itertools.count()
-
-        # tuple 구조: ( -priority, tiebreaker, Seed )
-        self.queue: List[tuple[int, int, Seed]] = []
-
+        self.queue: List[tuple[int, int, int]] = []
         self.load_from_db()
 
-
-    # Load all seeds from DB into the priority heap
     def load_from_db(self):
-        """DB에서 모든 Seed 로드 → 메모리 큐에 적재"""
+        self.queue.clear()
+        self._counter = itertools.count()
+
         for seed in self.manager.get_all():
+            if seed.id is None:
+                continue
+            if seed.status != "queued":
+                continue
             tiebreaker = next(self._counter)
-            heapq.heappush(self.queue, (-seed.priority, tiebreaker, seed))
-
-
-    # Push single seed
-    def push(self, seed: Seed):
-        """단일 Seed 추가"""
-
-        seed_id = self.manager.add_seed(seed)
-        seed.id = seed_id
+            heapq.heappush(self.queue, (-seed.priority, tiebreaker, seed.id))
+            
+    def push(self, seed_or_id: Union[Seed, int]):
+        if isinstance(seed_or_id, Seed):
+            seed_id = self.manager.add_seed(seed_or_id)
+            seed_or_id.id = seed_id
+            priority = seed_or_id.priority
+        else:
+            seed_id = int(seed_or_id)
+            seed = self.manager.get_seed(seed_id)
+            if seed is None:
+                return
+            priority = seed.priority
 
         tiebreaker = next(self._counter)
-        heapq.heappush(self.queue, (-seed.priority, tiebreaker, seed))
+        heapq.heappush(self.queue, (-priority, tiebreaker, seed_id))
 
-
-    # Push group of seeds (message-level)
     def push_group(self, seeds: List[Seed]):
-        """메시지 단위 Seed 그룹을 모두 추가"""
         for seed in seeds:
             self.push(seed)
 
-
-    # Pop highest priority seed
-    def pop(self) -> Optional[Seed]:
-        """가장 우선순위 높은 Seed 꺼내기"""
+    def pop(self) -> Optional[int]:
         if not self.queue:
             return None
 
-        _, _, seed = heapq.heappop(self.queue)
-        return seed
+        _, _, seed_id = heapq.heappop(self.queue)
+        return seed_id
 
-
-    # Update seed priority and reorder heap
     def update_priority(self, seed_id: int, delta: int):
-        """특정 Seed 우선순위 갱신 및 큐 재정렬"""
-
         updated = False
 
-        for i, (priority, tiebreaker, seed) in enumerate(self.queue):
-            if seed.id == seed_id:
+        for i, (priority, tiebreaker, queued_seed_id) in enumerate(self.queue):
+            if queued_seed_id == seed_id:
+                seed = self.manager.get_seed(seed_id)
+                if seed is None:
+                    return
 
-                # update priority value
-                seed.priority = max(1, min(seed.priority + delta, 10))
-                self.manager.update_priority(seed.id, seed.priority)
-
-                # replace heap entry
-                self.queue[i] = (-seed.priority, tiebreaker, seed)
-
+                new_priority = max(1, min(seed.priority + delta, 10))
+                self.manager.update_priority(seed_id, new_priority)
+                self.queue[i] = (-new_priority, tiebreaker, seed_id)
                 updated = True
                 break
 
         if updated:
             heapq.heapify(self.queue)
 
-
-    # Return list of seeds sorted by priority
     def list(self) -> List[Seed]:
-        """현재 큐 상태 반환 (우선순위 높은 순서)"""
-        sorted_list = sorted(self.queue, key=lambda x: (x[0], x[1]))
-        return [seed for _, _, seed in sorted_list]
+        sorted_queue = sorted(self.queue, key=lambda x: (x[0], x[1]))
+        out: List[Seed] = []
 
+        for _, _, seed_id in sorted_queue:
+            seed = self.manager.get_seed(seed_id)
+            if seed is not None:
+                out.append(seed)
 
-    # Close DB manager
+        return out
+
     def close(self):
         self.manager.close()

--- a/src/seeds/tx_log.py
+++ b/src/seeds/tx_log.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, List
+
+from .seed_manager import SeedManager
+
+
+@dataclass(frozen=True)
+class TxFrame:
+    arb_id: int
+    payload: bytes
+    dlc: int = 8
+
+
+class TxLog:
+    def __init__(self, seed_manager: SeedManager) -> None:
+        self.sm = seed_manager
+        self._create_table()
+
+    def _create_table(self) -> None:
+        self.sm.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS tx_log (
+                send_idx INTEGER PRIMARY KEY AUTOINCREMENT,
+                ts TEXT NOT NULL DEFAULT (datetime('now')),
+                arb_id INTEGER NOT NULL,
+                payload BLOB NOT NULL,
+                dlc INTEGER NOT NULL,
+                seed_id INTEGER NULL,
+                FOREIGN KEY(seed_id) REFERENCES seeds(id)
+            );
+            """
+        )
+        self.sm.conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_txlog_seed ON tx_log(seed_id, send_idx);"
+        )
+        self.sm.conn.commit()
+
+    def append(self, frame: TxFrame, seed_id: Optional[int] = None) -> int:
+        cur = self.sm.conn.cursor()
+        cur.execute(
+            """
+            INSERT INTO tx_log (arb_id, payload, dlc, seed_id)
+            VALUES (?, ?, ?, ?);
+            """,
+            (
+                frame.arb_id,
+                frame.payload,
+                frame.dlc,
+                seed_id,
+            ),
+        )
+        self.sm.conn.commit()
+        return int(cur.lastrowid)
+
+    def get_window(self, anchor_send_idx: int, pre: int, post: int) -> List[TxFrame]:
+        start = max(1, anchor_send_idx - max(0, pre))
+        end = anchor_send_idx + max(0, post)
+
+        rows = self.sm.conn.execute(
+            """
+            SELECT arb_id, payload, dlc
+            FROM tx_log
+            WHERE send_idx BETWEEN ? AND ?
+            ORDER BY send_idx ASC;
+            """,
+            (start, end),
+        ).fetchall()
+
+        frames: List[TxFrame] = []
+        for r in rows:
+            frames.append(
+                TxFrame(
+                    arb_id=int(r["arb_id"]),
+                    payload=bytes(r["payload"]),
+                    dlc=int(r["dlc"]),
+                )
+            )
+        return frames


### PR DESCRIPTION
## 📌 PR 개요
- CAN 버스 퍼징 파이프라인의 런타임 흐름을 Candidate 기반으로 재구성했습니다.
- 전송 → 모니터 → fail 판정 → 재현 → mutation 순서로 동작하도록 각 파일을 수정했습니다.

## 🔍 주요 변경 사항
- `monitor_manager.py` — `collect_results()` 추가 (모니터 결과 수집 후 dict 반환)
- `seed_manager.py` — `save_monitor_result()` 추가 (monitor 결과를 seed 레코드에 저장)
- `repro/candidate.py` — `CandidateSnapshot.from_seed()` 추가 (Seed → CandidateSnapshot 변환)
- `repro/reproducer.py` —  `send_raw()` 루프, TxLog Protocol 메서드명 `get_window()`로 수정
- `pipeline_candidate.py` — mutation 로직 제거, `send_one()` 메서드로 단일 전송 후 seed_id 반환하도록 변경

## ✅ 체크리스트


## ⚠️ 기타 참고 사항
- 전체 흐름을 notion에 정리했습니다. 

https://www.notion.so/pipeline-31eccb4b79c5804ab924dceebfcd992c